### PR TITLE
feat: Allow URL file and directory paths

### DIFF
--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/* global URL */
+
 //-----------------------------------------------------------------------------
 // Types
 //-----------------------------------------------------------------------------
@@ -41,13 +43,16 @@ export class ImplAlreadySetError extends Error {
 
 /**
  * Asserts that the given path is a valid file path.
- * @param {string} fileOrDirPath The path to check.
+ * @param {any} fileOrDirPath The path to check.
  * @returns {void}
  * @throws {TypeError} When the path is not a non-empty string.
  */
 function assertValidFileOrDirPath(fileOrDirPath) {
-	if (!fileOrDirPath || typeof fileOrDirPath !== "string") {
-		throw new TypeError("Path must be a non-empty string.");
+	if (
+		!fileOrDirPath ||
+		(!(fileOrDirPath instanceof URL) && typeof fileOrDirPath !== "string")
+	) {
+		throw new TypeError("Path must be a non-empty string or URL.");
 	}
 }
 
@@ -245,7 +250,7 @@ export class Hfs {
 
 	/**
 	 * Reads the given file and returns the contents as text. Assumes UTF-8 encoding.
-	 * @param {string} filePath The file to read.
+	 * @param {string|URL} filePath The file to read.
 	 * @returns {Promise<string|undefined>} The contents of the file.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
@@ -257,7 +262,7 @@ export class Hfs {
 
 	/**
 	 * Reads the given file and returns the contents as JSON. Assumes UTF-8 encoding.
-	 * @param {string} filePath The file to read.
+	 * @param {string|URL} filePath The file to read.
 	 * @returns {Promise<any|undefined>} The contents of the file as JSON.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {SyntaxError} When the file contents are not valid JSON.
@@ -270,7 +275,7 @@ export class Hfs {
 
 	/**
 	 * Reads the given file and returns the contents as an ArrayBuffer.
-	 * @param {string} filePath The file to read.
+	 * @param {string|URL} filePath The file to read.
 	 * @returns {Promise<ArrayBuffer|undefined>} The contents of the file as an ArrayBuffer.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
@@ -283,7 +288,7 @@ export class Hfs {
 
 	/**
 	 * Reads the given file and returns the contents as an Uint8Array.
-	 * @param {string} filePath The file to read.
+	 * @param {string|URL} filePath The file to read.
 	 * @returns {Promise<Uint8Array|undefined>} The contents of the file as an Uint8Array.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
@@ -296,7 +301,7 @@ export class Hfs {
 	/**
 	 * Writes the given data to the given file. Creates any necessary directories along the way.
 	 * If the data is a string, UTF-8 encoding is used.
-	 * @param {string} filePath The file to write.
+	 * @param {string|URL} filePath The file to write.
 	 * @param {any} contents The data to write.
 	 * @returns {Promise<void>} A promise that resolves when the file is written.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
@@ -310,7 +315,7 @@ export class Hfs {
 
 	/**
 	 * Determines if the given file exists.
-	 * @param {string} filePath The file to check.
+	 * @param {string|URL} filePath The file to check.
 	 * @returns {Promise<boolean>} True if the file exists.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
@@ -322,7 +327,7 @@ export class Hfs {
 
 	/**
 	 * Determines if the given directory exists.
-	 * @param {string} dirPath The directory to check.
+	 * @param {string|URL} dirPath The directory to check.
 	 * @returns {Promise<boolean>} True if the directory exists.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the directory path is not a non-empty string.
@@ -334,7 +339,7 @@ export class Hfs {
 
 	/**
 	 * Creates the given directory.
-	 * @param {string} dirPath The directory to create.
+	 * @param {string|URL} dirPath The directory to create.
 	 * @returns {Promise<void>} A promise that resolves when the directory is created.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the directory path is not a non-empty string.
@@ -346,7 +351,7 @@ export class Hfs {
 
 	/**
 	 * Deletes the given file.
-	 * @param {string} filePath The file to delete.
+	 * @param {string|URL} filePath The file to delete.
 	 * @returns {Promise<void>} A promise that resolves when the file is deleted.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
@@ -358,7 +363,7 @@ export class Hfs {
 
 	/**
 	 * Deletes the given directory.
-	 * @param {string} dirPath The directory to delete.
+	 * @param {string|URL} dirPath The directory to delete.
 	 * @returns {Promise<void>} A promise that resolves when the directory is deleted.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the directory path is not a non-empty string.
@@ -370,7 +375,7 @@ export class Hfs {
 
 	/**
 	 * Returns a list of directory entries for the given path.
-	 * @param {string} dirPath The path to the directory to read.
+	 * @param {string|URL} dirPath The path to the directory to read.
 	 * @returns {AsyncIterable<HfsDirectoryEntry>} A promise that resolves with the
 	 *   directory entries.
 	 * @throws {TypeError} If the directory path is not a string.
@@ -383,7 +388,7 @@ export class Hfs {
 
 	/**
 	 * Returns the size of the given file.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<number>} A promise that resolves with the size of the file.
 	 * @throws {TypeError} If the file path is not a string.
 	 * @throws {Error} If the file cannot be read.

--- a/packages/core/src/path.js
+++ b/packages/core/src/path.js
@@ -165,4 +165,29 @@ export class Path {
 	static fromString(fileOrDirPath) {
 		return new Path(normalizePath(fileOrDirPath).split("/"));
 	}
+
+	/**
+	 * Creates a new Path instance from a URL.
+	 * @param {URL} url The URL to convert.
+	 * @returns {Path} A new Path instance.
+	 * @throws {TypeError} When url is not a URL instance.
+	 * @throws {TypeError} When url.pathname is empty.
+	 * @throws {TypeError} When url.protocol is not "file:".
+	 */
+	static fromURL(url) {
+		if (!(url instanceof URL)) {
+			throw new TypeError("url must be a URL instance");
+		}
+
+		if (!url.pathname || url.pathname === "/") {
+			throw new TypeError("url.pathname cannot be empty");
+		}
+
+		if (url.protocol !== "file:") {
+			throw new TypeError(`url.protocol must be "file:"`);
+		}
+
+		// Remove leading slash in pathname
+		return new Path(normalizePath(url.pathname.slice(1)).split("/"));
+	}
 }

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -2,7 +2,7 @@
  * @fileoverview Tests for the Hfs class.
  * @author Nicholas C. Zakas
  */
-/* global it, describe */
+/* global it, describe, URL */
 
 //------------------------------------------------------------------------------
 // Imports
@@ -169,7 +169,7 @@ describe("Hfs", () => {
 	});
 
 	describe("text", () => {
-		it("should return the text from the file", async () => {
+		it("should return the text from the file with a string filePath", async () => {
 			const hfs = new Hfs({
 				impl: {
 					text() {
@@ -179,6 +179,21 @@ describe("Hfs", () => {
 			});
 
 			const result = await hfs.text("/path/to/file.txt");
+			assert.strictEqual(result, "Hello, world!");
+		});
+
+		it("should return the text from the file with a URL filePath", async () => {
+			const hfs = new Hfs({
+				impl: {
+					text() {
+						return "Hello, world!";
+					},
+				},
+			});
+
+			const result = await hfs.text(
+				new URL("http://example.com/file.txt"),
+			);
 			assert.strictEqual(result, "Hello, world!");
 		});
 
@@ -205,7 +220,7 @@ describe("Hfs", () => {
 			]);
 		});
 
-		it("should reject a promise when the file path is not a string", () => {
+		it("should reject a promise when the file path is not a string or URL", () => {
 			const hfs = new Hfs({
 				impl: {
 					text() {
@@ -216,7 +231,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.text(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -231,13 +246,13 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.text(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
 
 	describe("json", () => {
-		it("should return the JSON from the file", async () => {
+		it("should return the JSON from the file with a string filePath", async () => {
 			const hfs = new Hfs({
 				impl: {
 					json() {
@@ -247,6 +262,21 @@ describe("Hfs", () => {
 			});
 
 			const result = await hfs.json("/path/to/file.txt");
+			assert.deepStrictEqual(result, { foo: "bar" });
+		});
+
+		it("should return the JSON from the file with a URL filePath", async () => {
+			const hfs = new Hfs({
+				impl: {
+					json() {
+						return { foo: "bar" };
+					},
+				},
+			});
+
+			const result = await hfs.json(
+				new URL("http://example.com/file.txt"),
+			);
 			assert.deepStrictEqual(result, { foo: "bar" });
 		});
 
@@ -284,7 +314,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.json(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -299,13 +329,13 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.json(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
 
 	describe("arrayBuffer", () => {
-		it("should return the bytes from the file", async () => {
+		it("should return the bytes from the file with a string filePath", async () => {
 			const hfs = new Hfs({
 				impl: {
 					arrayBuffer() {
@@ -315,6 +345,21 @@ describe("Hfs", () => {
 			});
 
 			const result = await hfs.arrayBuffer("/path/to/file.txt");
+			assert.deepStrictEqual(result, new Uint8Array([1, 2, 3]).buffer);
+		});
+
+		it("should return the bytes from the file with a URL filePath", async () => {
+			const hfs = new Hfs({
+				impl: {
+					arrayBuffer() {
+						return new Uint8Array([1, 2, 3]).buffer;
+					},
+				},
+			});
+
+			const result = await hfs.arrayBuffer(
+				new URL("http://example.com/file.txt"),
+			);
 			assert.deepStrictEqual(result, new Uint8Array([1, 2, 3]).buffer);
 		});
 
@@ -373,7 +418,7 @@ describe("Hfs", () => {
 	});
 
 	describe("bytes", () => {
-		it("should return the bytes from the file", async () => {
+		it("should return the bytes from the file with a string filePath", async () => {
 			const hfs = new Hfs({
 				impl: {
 					bytes() {
@@ -383,6 +428,21 @@ describe("Hfs", () => {
 			});
 
 			const result = await hfs.bytes("/path/to/file.txt");
+			assert.deepStrictEqual(result, new Uint8Array([1, 2, 3]).buffer);
+		});
+
+		it("should return the bytes from the file with a URL filePath", async () => {
+			const hfs = new Hfs({
+				impl: {
+					bytes() {
+						return new Uint8Array([1, 2, 3]).buffer;
+					},
+				},
+			});
+
+			const result = await hfs.bytes(
+				new URL("http://example.com/file.txt"),
+			);
 			assert.deepStrictEqual(result, new Uint8Array([1, 2, 3]).buffer);
 		});
 
@@ -420,7 +480,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.bytes(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -435,7 +495,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.bytes(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
@@ -488,7 +548,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.bytes(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -503,7 +563,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.bytes(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
@@ -582,7 +642,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.write(123, "Hello, world!"),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -597,7 +657,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.write("", "Hello, world!"),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -678,7 +738,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.isFile(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -693,7 +753,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.isFile(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
@@ -893,7 +953,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.delete(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -908,7 +968,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.delete(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});
@@ -1089,7 +1149,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.size(123),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 
@@ -1104,7 +1164,7 @@ describe("Hfs", () => {
 
 			assert.rejects(
 				hfs.size(""),
-				new TypeError("File path must be a non-empty string."),
+				new TypeError("File path must be a non-empty string or URL."),
 			);
 		});
 	});

--- a/packages/core/tests/path.test.js
+++ b/packages/core/tests/path.test.js
@@ -353,4 +353,42 @@ describe("Path", () => {
 			assert.deepStrictEqual([...path], ["foo", "bar"]);
 		});
 	});
+
+	describe("static fromUrl()", () => {
+		it("should create a new Path instance from a valid URL", () => {
+			const url = new URL("file:///c:/foo/bar");
+			const path = Path.fromURL(url);
+			assert.deepStrictEqual([...path], ["foo", "bar"]);
+		});
+
+		it("should throw a TypeError when the URL is not a URL instance", () => {
+			const invalidUrl = "file:///c:/foo/bar";
+			assert.throws(
+				() => {
+					Path.fromURL(invalidUrl);
+				},
+				new TypeError("url must be a URL instance")
+			);
+		});
+
+		it("should throw a TypeError when the URL pathname is empty", () => {
+			const url = new URL("file:///");
+			assert.throws(
+				() => {
+					Path.fromURL(url);
+				},
+				new TypeError("url.pathname cannot be empty")
+			);
+		});
+
+		it("should throw a TypeError when the URL protocol is not 'file:'", () => {
+			const url = new URL("http://example.com/foo/bar");
+			assert.throws(
+				() => {
+					Path.fromURL(url);
+				},
+				new TypeError("url.protocol must be \"file:\"")
+			);
+		});
+	});
 });

--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -2,7 +2,7 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global TextEncoder, TextDecoder */
+/* global TextEncoder, TextDecoder, URL */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -42,11 +42,15 @@ function isDirectory(value) {
 /**
  * Finds a file or directory in the volume.
  * @param {object} volume The volume to search.
- * @param {string} fileOrDirPath The path to the file or directory to find.
+ * @param {string|URL} fileOrDirPath The path to the file or directory to find.
  * @returns {{object:object,key:string}|undefined} The file or directory found.
  */
 function findPath(volume, fileOrDirPath) {
-	const parts = [...Path.fromString(fileOrDirPath)];
+	const path =
+		fileOrDirPath instanceof URL
+			? Path.fromURL(fileOrDirPath)
+			: Path.fromString(fileOrDirPath);
+	const parts = [...path];
 
 	let object = volume;
 	let key = parts.shift();
@@ -66,7 +70,7 @@ function findPath(volume, fileOrDirPath) {
 /**
  * Finds a file or directory in the volume.
  * @param {object} volume The volume to search.
- * @param {string} fileOrDirPath The path to the file or directory to find.
+ * @param {string|URL} fileOrDirPath The path to the file or directory to find.
  * @returns {string|ArrayBuffer|object|undefined} The file or directory found.
  */
 function readPath(volume, fileOrDirPath) {
@@ -83,12 +87,16 @@ function readPath(volume, fileOrDirPath) {
 /**
  * Writes a file or directory to the volume.
  * @param {object} volume The volume to search.
- * @param {string} fileOrDirPath The path to the file or directory to find.
+ * @param {string|URL} fileOrDirPath The path to the file or directory to find.
  * @param {string|ArrayBuffer|object|undefined} value The value to write.
  * @returns {void}
  */
 function writePath(volume, fileOrDirPath, value) {
-	const parts = [...Path.fromString(fileOrDirPath)];
+	const path =
+		fileOrDirPath instanceof URL
+			? Path.fromURL(fileOrDirPath)
+			: Path.fromString(fileOrDirPath);
+	const parts = [...path];
 	let part = parts.shift();
 	let object = volume;
 
@@ -137,7 +145,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Reads a file and returns the contents as a string. Assumes UTF-8 encoding.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<string|undefined>} A promise that resolves with the contents of
 	 *     the file or undefined if the file does not exist.
 	 * @throws {TypeError} If the file path is not a string.
@@ -161,7 +169,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Reads a file and returns the contents as a JSON object. Assumes UTF-8 encoding.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<object|null>} A promise that resolves with the contents of
 	 *    the file or undefined if the file does not exist.
 	 * @throws {SyntaxError} If the file contents are not valid JSON.
@@ -176,7 +184,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Reads a file and returns the contents as an ArrayBuffer.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<ArrayBuffer|undefined>} A promise that resolves with the contents
 	 *    of the file or undefined if the file does not exist.
 	 * @throws {Error} If the file cannot be read.
@@ -199,7 +207,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Reads a file and returns the contents as an Uint8Array.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<Uint8Array|undefined>} A promise that resolves with the contents
 	 *    of the file or undefined if the file does not exist.
 	 * @throws {Error} If the file cannot be read.
@@ -221,7 +229,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Writes a value to a file. If the value is a string, UTF-8 encoding is used.
-	 * @param {string} filePath The path to the file to write.
+	 * @param {string|URL} filePath The path to the file to write.
 	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to write to the
 	 *   file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
@@ -248,7 +256,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Checks if a file exists.
-	 * @param {string} filePath The path to the file to check.
+	 * @param {string|URL} filePath The path to the file to check.
 	 * @returns {Promise<boolean>} A promise that resolves with true if the
 	 *    file exists or false if it does not.
 	 * @throws {TypeError} If the file path is not a string.
@@ -267,7 +275,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Checks if a directory exists.
-	 * @param {string} dirPath The path to the directory to check.
+	 * @param {string|URL} dirPath The path to the directory to check.
 	 * @returns {Promise<boolean>} A promise that resolves with true if the
 	 *    directory exists or false if it does not.
 	 * @throws {TypeError} If the directory path is not a string.
@@ -285,7 +293,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Creates a directory recursively.
-	 * @param {string} dirPath The path to the directory to create.
+	 * @param {string|URL} dirPath The path to the directory to create.
 	 * @returns {Promise<void>} A promise that resolves when the directory is
 	 *   created.
 	 */
@@ -295,7 +303,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Deletes a file or empty directory.
-	 * @param {string} fileOrDirPath The path to the file or directory to
+	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
 	 * @returns {Promise<void>} A promise that resolves when the file or
 	 *   directory is deleted.
@@ -318,7 +326,7 @@ export class MemoryHfsImpl {
 
 		if (isDirectory(value) && Object.keys(value).length > 0) {
 			throw new Error(
-				`EISDIR: illegal operation on a directory, unlink '${fileOrDirPath}'`,
+				`ENOTEMPTY: directory not empty, rmdir '${fileOrDirPath}'`,
 			);
 		}
 
@@ -327,7 +335,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Deletes a file or directory recursively.
-	 * @param {string} fileOrDirPath The path to the file or directory to
+	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
 	 * @returns {Promise<void>} A promise that resolves when the file or
 	 *   directory is deleted.
@@ -351,7 +359,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Returns a list of directory entries for the given path.
-	 * @param {string} dirPath The path to the directory to read.
+	 * @param {string|URL} dirPath The path to the directory to read.
 	 * @returns {AsyncIterable<HfsDirectoryEntry>} A promise that resolves with the
 	 *   directory entries.
 	 */
@@ -378,7 +386,7 @@ export class MemoryHfsImpl {
 
 	/**
 	 * Returns the size of a file.
-	 * @param {string} filePath The path to the file to read.
+	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<number|undefined>} A promise that resolves with the size of the
 	 *  file in bytes or undefined if the file doesn't exist.
 	 */

--- a/packages/types/src/hfs-types.ts
+++ b/packages/types/src/hfs-types.ts
@@ -13,14 +13,14 @@ export interface HfsImpl {
 	 * @param filePath The file to read.
 	 * @returns The contents of the file or undefined if the file is empty.
 	 */
-	text?(filePath: string): Promise<string|undefined>;
+	text?(filePath: string|URL): Promise<string|undefined>;
 
 	/**
 	 * Reads the given file and returns the contents as JSON. Assumes the file is UTF-8 encoded.
 	 * @param filePath The file to read.
 	 * @returns The contents of the file as JSON or undefined if the file is empty.
 	 */
-	json?(filePath: string): Promise<any|undefined>;
+	json?(filePath: string|URL): Promise<any|undefined>;
 
 	/**
 	 * Reads the given file and returns the contents as an ArrayBuffer.
@@ -28,14 +28,14 @@ export interface HfsImpl {
 	 * @returns The contents of the file as an ArrayBuffer or undefined if the file is empty.
 	 * @deprecated Use bytes() instead.
 	 */
-	arrayBuffer?(filePath: string): Promise<ArrayBuffer|undefined>;
+	arrayBuffer?(filePath: string|URL): Promise<ArrayBuffer|undefined>;
 
 	/**
 	 * Reads the given file and returns the contents as an Uint8Array.
 	 * @param filePath The file to read.
 	 * @returns The contents of the file as a Uint8Array or undefined if the file is empty.
 	 */
-	bytes?(filePath: string): Promise<Uint8Array|undefined>;
+	bytes?(filePath: string|URL): Promise<Uint8Array|undefined>;
 
 	/**
 	 * Writes the given data to the given file. For text, assumes UTF-8 encoding.
@@ -44,7 +44,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the file is written.
 	 * @throws {Error} If the file cannot be written.
 	 */
-	write?(filePath: string, data: string|ArrayBuffer|ArrayBufferView): Promise<void>;
+	write?(filePath: string|URL, data: string|ArrayBuffer|ArrayBufferView): Promise<void>;
 
 	/**
 	 * Checks if the given file exists.
@@ -52,7 +52,7 @@ export interface HfsImpl {
 	 * @returns True if the file exists, false if not.
 	 * @throws {Error} If the operation fails with a code other than ENOENT.
 	 */
-	isFile?(filePath: string): Promise<boolean>;
+	isFile?(filePath: string|URL): Promise<boolean>;
 
 	/**
 	 * Checks if the given directory exists.
@@ -60,7 +60,7 @@ export interface HfsImpl {
 	 * @returns True if the directory exists, false if not.
 	 * @throws {Error} If the operation fails with a code other than ENOENT.
 	 */
-	isDirectory?(dirPath: string): Promise<boolean>;
+	isDirectory?(dirPath: string|URL): Promise<boolean>;
 
 	/**
 	 * Creates the given directory, including any necessary parents.
@@ -68,7 +68,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the directory is created.
 	 * @throws {Error} If the directory cannot be created.
 	 */
-	createDirectory?(dirPath: string): Promise<void>;
+	createDirectory?(dirPath: string|URL): Promise<void>;
 
 	/**
 	 * Deletes the given file or empty directory.
@@ -76,7 +76,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the file or directory is deleted.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
-	delete?(fileOrDirPath: string): Promise<void>;
+	delete?(fileOrDirPath: string|URL): Promise<void>;
 
 	/**
 	 * Deletes the given file or directory recursively.
@@ -84,7 +84,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the file or directory is deleted.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
-	deleteAll?(fileOrDirPath: string): Promise<void>;
+	deleteAll?(fileOrDirPath: string|URL): Promise<void>;
 
 	/**
 	 * Returns a list of directory entries for the given path.
@@ -94,7 +94,7 @@ export interface HfsImpl {
 	 * @throws {TypeError} If the directory path is not a string.
 	 * @throws {Error} If the directory cannot be read.
 	 */
-	list?(dirPath:string): AsyncIterable<HfsDirectoryEntry>;
+	list?(dirPath: string|URL): AsyncIterable<HfsDirectoryEntry>;
 
 	/**
 	 * Returns the size of the given file.
@@ -103,7 +103,7 @@ export interface HfsImpl {
 	 * 		undefined if the file does not exist.
 	 * @throws {Error} If the file cannot be read.
 	 */
-	size?(filePath: string): Promise<number|undefined>;
+	size?(filePath: string|URL): Promise<number|undefined>;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Allow all methods to accept `URL` arguments in addition to string paths.

## What changes did you make? (Give an overview)

- Updated the `HfsImpl` type to include `URL` in the method definitions
- Updated each runtime package
- Added tests for `URL` arguments in `HfsImplTester`
- Fixed some broken tests in `HfsImplTester`
<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
