### PR TITLE
fix: Writing files at the root.

### DIFF
--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -96,27 +96,26 @@ function writePath(volume, fileOrDirPath, value) {
 		fileOrDirPath instanceof URL
 			? Path.fromURL(fileOrDirPath)
 			: Path.fromString(fileOrDirPath);
-	const parts = [...path];
-	let part = parts.shift();
-	let object = volume;
+	const name = path.pop();
+	let directory = volume;
 
-	do {
-		let entry = object[part];
+	// create any missing directories
+	for (const step of path) {
+		let entry = directory[step];
 
 		if (!entry) {
-			entry = object[part] = {};
+			entry = directory[step] = {};
 		}
 
-		object = entry;
-		part = parts.shift();
-	} while (parts.length > 0);
+		directory = entry;
+	}
 
 	// we don't want to overwrite an existing directory
-	if (object && isDirectory(object[part]) && isDirectory(value)) {
+	if (directory && isDirectory(directory[name]) && isDirectory(value)) {
 		return;
 	}
 
-	object[part] = value;
+	directory[name] = value;
 }
 
 //-----------------------------------------------------------------------------

--- a/packages/memory/tests/memory-hfs.test.js
+++ b/packages/memory/tests/memory-hfs.test.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/*global describe, it */
+
 //------------------------------------------------------------------------------
 // Imports
 //------------------------------------------------------------------------------
@@ -37,4 +39,17 @@ await tester.test({
 await tester.test({
 	name: "MemoryHfsImpl (without volume)",
 	impl: new MemoryHfsImpl(),
+});
+
+describe("MemoryHfsImpl Customizations", () => {
+	describe("delete()", () => {
+		// https://github.com/humanwhocodes/humanfs/issues/74
+		it("should delete a file that was just written at the root", async () => {
+			const impl = new MemoryHfsImpl();
+			await impl.write("foo.txt", "bar");
+			await impl.delete("foo.txt");
+			const result = await impl.isFile("foo.txt");
+			assert.strictEqual(result, false);
+		});
+	});
 });


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Fixes the behavior of `MemoryHfsImpl` when writing to the root of the volume.

## What changes did you make? (Give an overview)

- Updated the `write()` method logic for finding the path to write
- Added a test

## What issue(s) does this PR address?

fixes #74

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
