### PR TITLE
feat!: Rewrite MemoryHfsImpl to support lastModified()

### DIFF
--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -416,16 +416,15 @@ export class Hfs {
 	}
 
 	/**
-	 * Returns the last modified timestamp of the given file.
-	 * @param {string|URL} filePath The path to the file.
+	 * Returns the last modified timestamp of the given file or directory.
+	 * @param {string|URL} fileOrDirPath The path to the file or directory.
 	 * @returns {Promise<Date|undefined>} A promise that resolves with the last modified date
-	 *  or undefined if the file does not exist.
-	 * @throws {TypeError} If the file path is not a string or URL.
-	 * @throws {Error} If the file does not exist or cannot be accessed.
+	 *  or undefined if the file or directory does not exist.
+	 * @throws {TypeError} If the path is not a string or URL.
 	 */
-	async lastModified(filePath) {
-		assertValidFileOrDirPath(filePath);
-		return this.#callImplMethod("lastModified", filePath);
+	async lastModified(fileOrDirPath) {
+		assertValidFileOrDirPath(fileOrDirPath);
+		return this.#callImplMethod("lastModified", fileOrDirPath);
 	}
 
 	/**

--- a/packages/deno/src/deno-hfs.js
+++ b/packages/deno/src/deno-hfs.js
@@ -343,15 +343,15 @@ export class DenoHfsImpl {
 	}
 
 	/**
-	 * Returns the last modified date of a file. This method handles ENOENT errors
+	 * Returns the last modified date of a file or directory. This method handles ENOENT errors
 	 * and returns undefined in that case.
-	 * @param {string|URL} filePath The path to the file to read.
+	 * @param {string|URL} fileOrDirPath The path to the file to read.
 	 * @returns {Promise<Date|undefined>} A promise that resolves with the last modified
-	 * date of the file or undefined if the file doesn't exist.
+	 * date of the file or directory, or undefined if the file doesn't exist.
 	 */
-	lastModified(filePath) {
+	lastModified(fileOrDirPath) {
 		return this.#deno
-			.stat(filePath)
+			.stat(fileOrDirPath)
 			.then(stat => stat.mtime)
 			.catch(error => {
 				if (error.code === "ENOENT") {

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -111,6 +111,9 @@ const found = await hfs.isFile("file.txt");
 // how big is the file?
 const size = await hfs.size("file.txt");
 
+// when was the file modified?
+const mtime = await hfs.lastModified("file.txt");
+
 // copy a file from one location to another
 await hfs.copy("file.txt", "file-copy.txt");
 
@@ -150,10 +153,6 @@ If you'd like to create your own instance, import the `MemoryHfs` constructor:
 import { MemoryHfs } from "@humanfs/memory";
 
 const hfs = new MemoryHfs();
-
-// optionally specify the object to use when storing data
-const volume = {};
-const hfs = new MemoryHfs({ volume });
 ```
 
 If you'd like to use just the impl, import the `MemoryHfsImpl` constructor:
@@ -162,10 +161,6 @@ If you'd like to use just the impl, import the `MemoryHfsImpl` constructor:
 import { MemoryHfsImpl } from "@humanfs/memory";
 
 const hfs = new MemoryHfsImpl();
-
-// optionally specify the object to use when storing data
-const volume = {};
-const hfs = new MemoryHfsImpl({ volume });
 ```
 
 ## License

--- a/packages/memory/tests/memory-hfs.test.js
+++ b/packages/memory/tests/memory-hfs.test.js
@@ -17,7 +17,6 @@ import assert from "node:assert";
 // Helpers
 //------------------------------------------------------------------------------
 
-const volume = {};
 const fixturesDir = "fixtures";
 
 //------------------------------------------------------------------------------
@@ -32,12 +31,7 @@ const tester = new HfsImplTester({
 });
 
 await tester.test({
-	name: "MemoryHfsImpl (with volume)",
-	impl: new MemoryHfsImpl({ volume }),
-});
-
-await tester.test({
-	name: "MemoryHfsImpl (without volume)",
+	name: "MemoryHfsImpl",
 	impl: new MemoryHfsImpl(),
 });
 
@@ -50,6 +44,14 @@ describe("MemoryHfsImpl Customizations", () => {
 			await impl.delete("foo.txt");
 			const result = await impl.isFile("foo.txt");
 			assert.strictEqual(result, false);
+		});
+	});
+
+	describe("text()", () => {
+		it("should return undefined when reading toString", async () => {
+			const impl = new MemoryHfsImpl();
+			const result = await impl.text("toString");
+			assert.strictEqual(result, undefined);
 		});
 	});
 });

--- a/packages/node/src/node-hfs.js
+++ b/packages/node/src/node-hfs.js
@@ -392,15 +392,15 @@ export class NodeHfsImpl {
 	}
 
 	/**
-	 * Returns the last modified date of a file. This method handles ENOENT errors
+	 * Returns the last modified date of a file or directory. This method handles ENOENT errors
 	 * and returns undefined in that case.
-	 * @param {string|URL} filePath The path to the file to read.
+	 * @param {string|URL} fileOrDirPath The path to the file to read.
 	 * @returns {Promise<Date|undefined>} A promise that resolves with the last modified
-	 * date of the file or undefined if the file doesn't exist.
+	 * date of the file or directory, or undefined if the file doesn't exist.
 	 */
-	lastModified(filePath) {
+	lastModified(fileOrDirPath) {
 		return this.#fsp
-			.stat(filePath)
+			.stat(fileOrDirPath)
 			.then(stat => stat.mtime)
 			.catch(error => {
 				if (error.code === "ENOENT") {

--- a/packages/test/src/hfs-impl-tester.js
+++ b/packages/test/src/hfs-impl-tester.js
@@ -1215,6 +1215,11 @@ export class HfsImplTester {
 						assert.ok(result instanceof Date);
 					});
 
+					it("should return the last modified date of a directory", async () => {
+						const result = await impl.lastModified(this.#outputDir);
+						assert.ok(result instanceof Date);
+					});
+
 					it("should return the last modified date of a file when using a file URL", async () => {
 						const filePath = this.#outputDir + "/hello.txt";
 						const fileUrl = filePathToUrl(filePath);
@@ -1225,6 +1230,12 @@ export class HfsImplTester {
 					it("should return undefined if the file doesn't exist", async () => {
 						const filePath = this.#outputDir + "/nonexistent.txt";
 						const result = await impl.lastModified(filePath);
+						assert.strictEqual(result, undefined);
+					});
+
+					it("should return undefined if the directory doesn't exist", async () => {
+						const dirPath = this.#outputDir + "/nonexistent";
+						const result = await impl.lastModified(dirPath);
 						assert.strictEqual(result, undefined);
 					});
 

--- a/packages/types/src/hfs-types.ts
+++ b/packages/types/src/hfs-types.ts
@@ -115,13 +115,13 @@ export interface HfsImpl {
 	size?(filePath: string|URL): Promise<number|undefined>;
 
 	/**
-	 * Returns the last modified date of the given file.
-	 * @param filePath The path to the file to check.
+	 * Returns the last modified date of the given file or directory.
+	 * @param fileOrDirPath The path to the file or directory to check.
 	 * @returns A promise that resolves with the last modified date of the file or
-	 * 		undefined if the file does not exist.
-	 * @throws {Error} If the file cannot be read.
+	 * 		directory, undefined if the file does not exist.
+	 * @throws {Error} If the file or directory cannot be read.
 	 */
-	lastModified?(filePath: string|URL): Promise<Date|undefined>;
+	lastModified?(fileOrDirPath: string|URL): Promise<Date|undefined>;
 
 	/**
 	 * Copies the file from the source path to the destination path.


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Rewrote `MemoryHfsImpl` to supported `lastModified`. This involved reworking the underlying object hierarchy used to mimic a fil system.

## What changes did you make? (Give an overview)

- Updated `MemoryHfsImpl` to remove the options argument
- Created internal-only `MemoryHfsFile` and `MemoryHfsDirectory` to manage file system
- Updated `HfsImplTester` tests to ensure directories were being tested with `lastModified()`
- Fixed `WebHfsImpl` so that `lastModified()` on directories works
- Updated docs

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
