### PR TITLE
feat: Impls only need bytes() method to read data

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,3 +1,17 @@
+# 2024-02-22 Impls only need to implements `bytes()` to read files.
+
+## Background
+
+Originally, impls needed to implement `text()`, `json()`, `arrayBuffer()`, and `bytes()` to support all ways of reading a file.
+
+## Decision
+
+Impls need only implement `bytes()`; the `text()`, `json()`, and `arrayBuffer()` methods will exist only on `Hfs` and will use `bytes()` from the impl.
+
+## Rationale
+
+In implementing multiple different impls, it became clear that there was a lot of unnecessarily duplication of functionality. For instance, `json()` is just `text()` passed through `JSON.parse()`, so that could be moved to the `Hfs` class. Further `arrayBuffer()` is just `bytes()` and then accessing the `buffer` property, and even further, `text()` can be implemented with `bytes()` and `TextDecoder`. Impls should not need to share code from other impls, and so refocusing on `bytes()` as the primary impl read method reduces development time and the amount of code necessary to create an impl.
+
 # 2024-02-14 The `lastModified()` method should return a `Date`
 
 ## Background

--- a/packages/deno/src/deno-hfs.js
+++ b/packages/deno/src/deno-hfs.js
@@ -58,57 +58,6 @@ export class DenoHfsImpl {
 	}
 
 	/**
-	 * Reads a file and returns the contents as a string. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<string>} A promise that resolves with the contents of
-	 *     the file.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @throws {RangeError} If the file path is empty.
-	 * @throws {RangeError} If the file path is not absolute.
-	 * @throws {RangeError} If the file path is not a file.
-	 * @throws {RangeError} If the file path is not readable.
-	 */
-	text(filePath) {
-		return this.#retrier
-			.retry(() => this.#deno.readTextFile(filePath))
-			.catch(error => {
-				if (error.code === "ENOENT") {
-					return undefined;
-				}
-
-				throw error;
-			});
-	}
-
-	/**
-	 * Reads a file and returns the contents as a JSON object. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<object>} A promise that resolves with the contents of
-	 *    the file.
-	 * @throws {SyntaxError} If the file contents are not valid JSON.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 */
-	json(filePath) {
-		return this.text(filePath).then(text =>
-			text === undefined ? text : JSON.parse(text),
-		);
-	}
-
-	/**
-	 * Reads a file and returns the contents as an ArrayBuffer.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<ArrayBuffer|undefined>} A promise that resolves with the contents
-	 *    of the file.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @deprecated Use bytes() instead.
-	 */
-	arrayBuffer(filePath) {
-		return this.bytes(filePath).then(bytes => bytes?.buffer);
-	}
-
-	/**
 	 * Reads a file and returns the contents as an Uint8Array.
 	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<Uint8Array|undefined>} A promise that resolves with the contents

--- a/packages/deno/tests/deno-hfs.test.js
+++ b/packages/deno/tests/deno-hfs.test.js
@@ -100,112 +100,9 @@ describe("DenoHfsImpl Customizations", () => {
 		});
 	});
 
-	describe("text()", () => {
-		it("should return text contents when ENFILE error occurs", async () => {
-			let callCount = 0;
-			const impl = new DenoHfsImpl({
-				deno: {
-					async readTextFile() {
-						if (callCount === 0) {
-							callCount++;
-							const error = new Error(
-								"ENFILE: file table overflow",
-							);
-							error.code = "ENFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assertEquals(result, "Hello world!");
-		});
-
-		it("should return text contents when EMFILE error occurs", async () => {
-			let callCount = 0;
-			const impl = new DenoHfsImpl({
-				deno: {
-					async readTextFile() {
-						if (callCount === 0) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assertEquals(result, "Hello world!");
-		});
-
-		it("should return text contents when EMFILE error occurs multiple times", async () => {
-			let callCount = 0;
-			const impl = new DenoHfsImpl({
-				deno: {
-					async readTextFile() {
-						if (callCount < 3) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assertEquals(result, "Hello world!");
-		});
-
-		it("should rethrow an error that isn't ENFILE", async () => {
-			const impl = new DenoHfsImpl({
-				deno: {
-					async readTextFile() {
-						throw new Error("Boom!");
-					},
-				},
-			});
-			await assertRejects(() => impl.text(".hfs/foo"), /Boom!/);
-		});
-
-		it("should rethrow an error that isn't ENFILE after ENFILE occurs", async () => {
-			let callCount = 0;
-			const impl = new DenoHfsImpl({
-				deno: {
-					async readTextFile() {
-						if (callCount < 3) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						throw new Error("Boom!");
-					},
-				},
-			});
-			await assertRejects(() => impl.text(".hfs/foo"), /Boom!/);
-		});
-	});
-
-	describe("arrayBuffer()", () => {
+	describe("bytes()", () => {
 		it("should return contents when ENFILE error occurs", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new DenoHfsImpl({
 				deno: {
@@ -224,12 +121,12 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
+			const result = await impl.bytes(".hfs/foo");
 			assertEquals(result, contents);
 		});
 
 		it("should return contents when EMFILE error occurs", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new DenoHfsImpl({
 				deno: {
@@ -248,12 +145,12 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
+			const result = await impl.bytes(".hfs/foo");
 			assertEquals(result, contents);
 		});
 
 		it("should return text contents when EMFILE error occurs multiple times", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new DenoHfsImpl({
 				deno: {
@@ -272,7 +169,7 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
+			const result = await impl.bytes(".hfs/foo");
 			assertEquals(result, contents);
 		});
 
@@ -284,7 +181,7 @@ describe("DenoHfsImpl Customizations", () => {
 					},
 				},
 			});
-			await assertRejects(() => impl.arrayBuffer(".hfs/foo"), /Boom!/);
+			await assertRejects(() => impl.bytes(".hfs/foo"), /Boom!/);
 		});
 	});
 

--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -2,7 +2,7 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global TextEncoder, TextDecoder, URL */
+/* global TextEncoder, URL */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -259,61 +259,6 @@ export class MemoryHfsImpl {
 	#root = new MemoryHfsDirectory();
 
 	/**
-	 * Reads a file and returns the contents as a string. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<string|undefined>} A promise that resolves with the contents of
-	 *     the file or undefined if the file does not exist.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @throws {RangeError} If the file path is not absolute.
-	 * @throws {RangeError} If the file path is not a file.
-	 * @throws {RangeError} If the file path is not readable.
-	 */
-	async text(filePath) {
-		const bytes = await this.bytes(filePath);
-
-		if (bytes === undefined) {
-			return undefined;
-		}
-
-		return new TextDecoder().decode(bytes);
-	}
-
-	/**
-	 * Reads a file and returns the contents as a JSON object. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<object|null>} A promise that resolves with the contents of
-	 *    the file or undefined if the file does not exist.
-	 * @throws {SyntaxError} If the file contents are not valid JSON.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 */
-	async json(filePath) {
-		return this.text(filePath).then(text =>
-			text === undefined ? text : JSON.parse(text),
-		);
-	}
-
-	/**
-	 * Reads a file and returns the contents as an ArrayBuffer.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<ArrayBuffer|undefined>} A promise that resolves with the contents
-	 *    of the file or undefined if the file does not exist.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @deprecated Use bytes() instead.
-	 */
-	async arrayBuffer(filePath) {
-		const entry = readPath(this.#root, filePath);
-
-		if (entry?.kind !== "file") {
-			return undefined;
-		}
-
-		const file = /** @type {MemoryHfsFile} */ (entry);
-		return file.contents;
-	}
-
-	/**
 	 * Reads a file and returns the contents as an Uint8Array.
 	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<Uint8Array|undefined>} A promise that resolves with the contents
@@ -322,8 +267,14 @@ export class MemoryHfsImpl {
 	 * @throws {TypeError} If the file path is not a string.
 	 */
 	async bytes(filePath) {
-		const buffer = await this.arrayBuffer(filePath);
-		return buffer ? new Uint8Array(buffer) : undefined;
+		const entry = readPath(this.#root, filePath);
+
+		if (entry?.kind !== "file") {
+			return undefined;
+		}
+
+		const file = /** @type {MemoryHfsFile} */ (entry);
+		return file.contents ? new Uint8Array(file.contents) : undefined;
 	}
 
 	/**

--- a/packages/memory/tests/memory-hfs.test.js
+++ b/packages/memory/tests/memory-hfs.test.js
@@ -47,10 +47,10 @@ describe("MemoryHfsImpl Customizations", () => {
 		});
 	});
 
-	describe("text()", () => {
+	describe("bytes()", () => {
 		it("should return undefined when reading toString", async () => {
 			const impl = new MemoryHfsImpl();
-			const result = await impl.text("toString");
+			const result = await impl.bytes("toString");
 			assert.strictEqual(result, undefined);
 		});
 	});

--- a/packages/node/src/node-hfs.js
+++ b/packages/node/src/node-hfs.js
@@ -106,59 +106,6 @@ export class NodeHfsImpl {
 	}
 
 	/**
-	 * Reads a file and returns the contents as a string. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<string|undefined>} A promise that resolves with the contents of
-	 *     the file or undefined if the file doesn't exist.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @throws {RangeError} If the file path is empty.
-	 * @throws {RangeError} If the file path is not absolute.
-	 * @throws {RangeError} If the file path is not a file.
-	 * @throws {RangeError} If the file path is not readable.
-	 */
-	text(filePath) {
-		return this.#retrier
-			.retry(() => this.#fsp.readFile(filePath, "utf8"))
-			.catch(error => {
-				if (error.code === "ENOENT") {
-					return undefined;
-				}
-
-				throw error;
-			});
-	}
-
-	/**
-	 * Reads a file and returns the contents as a JSON object. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<object|undefined>} A promise that resolves with the contents of
-	 *    the file or undefined if the file doesn't exist.
-	 * @throws {SyntaxError} If the file contents are not valid JSON.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 */
-	json(filePath) {
-		return this.text(filePath).then(text =>
-			text === undefined ? text : JSON.parse(text),
-		);
-	}
-
-	/**
-	 * Reads a file and returns the contents as an ArrayBuffer.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<ArrayBuffer|undefined>} A promise that resolves with the contents
-	 *    of the file or undefined if the file doesn't exist.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @deprecated Use bytes() instead.
-	 */
-	arrayBuffer(filePath) {
-		return this.bytes(filePath).then(bytes =>
-			bytes === undefined ? bytes : bytes.buffer,
-		);
-	}
-
-	/**
 	 * Reads a file and returns the contents as an Uint8Array.
 	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<Uint8Array|undefined>} A promise that resolves with the contents

--- a/packages/node/tests/node-hfs.test.js
+++ b/packages/node/tests/node-hfs.test.js
@@ -84,112 +84,9 @@ describe("NodeHfsImpl Customizations", () => {
 		});
 	});
 
-	describe("text()", () => {
-		it("should return text contents when ENFILE error occurs", async () => {
-			let callCount = 0;
-			const impl = new NodeHfsImpl({
-				fsp: {
-					async readFile() {
-						if (callCount === 0) {
-							callCount++;
-							const error = new Error(
-								"ENFILE: file table overflow",
-							);
-							error.code = "ENFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assert.strictEqual(result, "Hello world!");
-		});
-
-		it("should return text contents when EMFILE error occurs", async () => {
-			let callCount = 0;
-			const impl = new NodeHfsImpl({
-				fsp: {
-					async readFile() {
-						if (callCount === 0) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assert.strictEqual(result, "Hello world!");
-		});
-
-		it("should return text contents when EMFILE error occurs multiple times", async () => {
-			let callCount = 0;
-			const impl = new NodeHfsImpl({
-				fsp: {
-					async readFile() {
-						if (callCount < 3) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						return "Hello world!";
-					},
-				},
-			});
-
-			const result = await impl.text(".hfs/foo");
-			assert.strictEqual(result, "Hello world!");
-		});
-
-		it("should rethrow an error that isn't ENFILE", async () => {
-			const impl = new NodeHfsImpl({
-				fsp: {
-					async readFile() {
-						throw new Error("Boom!");
-					},
-				},
-			});
-			await assert.rejects(() => impl.text(".hfs/foo"), /Boom!/);
-		});
-
-		it("should rethrow an error that isn't ENFILE after ENFILE occurs", async () => {
-			let callCount = 0;
-			const impl = new NodeHfsImpl({
-				fsp: {
-					async readFile() {
-						if (callCount < 3) {
-							callCount++;
-							const error = new Error(
-								"EMFILE: file table overflow",
-							);
-							error.code = "EMFILE";
-							throw error;
-						}
-
-						throw new Error("Boom!");
-					},
-				},
-			});
-			await assert.rejects(() => impl.text(".hfs/foo"), /Boom!/);
-		});
-	});
-
-	describe("arrayBuffer()", () => {
+	describe("bytes()", () => {
 		it("should return contents when ENFILE error occurs", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new NodeHfsImpl({
 				fsp: {
@@ -203,17 +100,17 @@ describe("NodeHfsImpl Customizations", () => {
 							throw error;
 						}
 
-						return Buffer.from(contents);
+						return Buffer.from(contents.buffer);
 					},
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
-			assert.strictEqual(result, contents);
+			const result = await impl.bytes(".hfs/foo");
+			assert.deepStrictEqual(result, contents);
 		});
 
 		it("should return contents when EMFILE error occurs", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new NodeHfsImpl({
 				fsp: {
@@ -227,17 +124,17 @@ describe("NodeHfsImpl Customizations", () => {
 							throw error;
 						}
 
-						return Buffer.from(contents);
+						return Buffer.from(contents.buffer);
 					},
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
-			assert.strictEqual(result, contents);
+			const result = await impl.bytes(".hfs/foo");
+			assert.deepStrictEqual(result, contents);
 		});
 
 		it("should return text contents when EMFILE error occurs multiple times", async () => {
-			const contents = new TextEncoder().encode("Hello world!").buffer;
+			const contents = new TextEncoder().encode("Hello world!");
 			let callCount = 0;
 			const impl = new NodeHfsImpl({
 				fsp: {
@@ -251,13 +148,13 @@ describe("NodeHfsImpl Customizations", () => {
 							throw error;
 						}
 
-						return Buffer.from(contents);
+						return Buffer.from(contents.buffer);
 					},
 				},
 			});
 
-			const result = await impl.arrayBuffer(".hfs/foo");
-			assert.strictEqual(result, contents);
+			const result = await impl.bytes(".hfs/foo");
+			assert.deepStrictEqual(result, contents);
 		});
 
 		it("should rethrow an error that isn't ENFILE", async () => {
@@ -268,7 +165,7 @@ describe("NodeHfsImpl Customizations", () => {
 					},
 				},
 			});
-			await assert.rejects(() => impl.arrayBuffer(".hfs/foo"), /Boom!/);
+			await assert.rejects(() => impl.bytes(".hfs/foo"), /Boom!/);
 		});
 	});
 

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -77,11 +77,11 @@ import { HfsImplTester } from "https://cdn.skypack.dev/@humanfs/test";
 
 At a minimum, an impl must implement these methods to use `HfsImplTester`:
 
+* `bytes()`
 * `createDirectory()`
 * `deleteAll()`
 * `isDirectory()`
 * `isFile()`
-* `text()`
 * `write()`
 
 ### The `HfsImplTester` Class

--- a/packages/test/src/hfs-impl-tester.js
+++ b/packages/test/src/hfs-impl-tester.js
@@ -122,135 +122,6 @@ export class HfsImplTester {
 				await impl.deleteAll(this.#outputDir);
 			});
 
-			describe("text()", () => {
-				it("should read a file with a filename and return the contents as a string", async () => {
-					const filePath = this.#outputDir + "/hello.txt";
-					const result = await impl.text(filePath);
-					assert.strictEqual(result, "Hello world!\n");
-				});
-
-				it("should read a file with a file URL and return the contents as a string", async () => {
-					const filePath = this.#outputDir + "/hello.txt";
-					const fileUrl = filePathToUrl(filePath);
-					const result = await impl.text(fileUrl);
-					assert.strictEqual(result, "Hello world!\n");
-				});
-
-				it("should return undefined when a file with the given filename doesn't exist", async () => {
-					const result = await impl.text(
-						this.#outputDir + "/nonexistent.txt",
-					);
-					assert.strictEqual(
-						result,
-						undefined,
-						"Expected undefined when reading a nonexistent file",
-					);
-				});
-
-				it("should return undefined when a file with the given file URL doesn't exist", async () => {
-					const result = await impl.text(
-						filePathToUrl(this.#outputDir + "/nonexistent.txt"),
-					);
-					assert.strictEqual(
-						result,
-						undefined,
-						"Expected undefined when reading a nonexistent file",
-					);
-				});
-			});
-
-			if (impl.json) {
-				describe("json()", () => {
-					it("should read a file and return the contents as a JSON object", async () => {
-						const filePath = this.#outputDir + "/message.json";
-						const result = await impl.json(filePath);
-						assert.deepStrictEqual(result, {
-							message: "Hello world!",
-						});
-					});
-
-					it("should read a file and return the contents as a JSON object when using a file URL", async () => {
-						const filePath = this.#outputDir + "/message.json";
-						const fileUrl = filePathToUrl(filePath);
-						const result = await impl.json(fileUrl);
-						assert.deepStrictEqual(result, {
-							message: "Hello world!",
-						});
-					});
-
-					it("should return undefined when a file doesn't exist", async () => {
-						const result = await impl.json(
-							this.#outputDir + "/nonexistent.txt",
-						);
-						assert.strictEqual(
-							result,
-							undefined,
-							"Expected undefined when reading a nonexistent file",
-						);
-					});
-
-					it("should return undefined when a file with the given file URL doesn't exist", async () => {
-						const result = await impl.json(
-							filePathToUrl(this.#outputDir + "/nonexistent.txt"),
-						);
-						assert.strictEqual(
-							result,
-							undefined,
-							"Expected undefined when reading a nonexistent file",
-						);
-					});
-				});
-			}
-
-			if (impl.arrayBuffer) {
-				describe("arrayBuffer()", () => {
-					it("should read a file and return the contents as an ArrayBuffer", async () => {
-						const filePath = this.#outputDir + "/hello.txt";
-						const result = await impl.arrayBuffer(filePath);
-						assert.ok(result instanceof ArrayBuffer);
-						const decoder = new TextDecoder();
-						assert.strictEqual(
-							decoder.decode(result),
-							"Hello world!\n",
-						);
-					});
-
-					it("should read a file and return the contents as an ArrayBuffer when using a file URL", async () => {
-						const filePath = this.#outputDir + "/hello.txt";
-						const fileUrl = filePathToUrl(filePath);
-						const result = await impl.arrayBuffer(fileUrl);
-						assert.ok(result instanceof ArrayBuffer);
-						const decoder = new TextDecoder();
-						assert.strictEqual(
-							decoder.decode(result),
-							"Hello world!\n",
-						);
-					});
-
-					it("should return undefined when a file doesn't exist", async () => {
-						const result = await impl.arrayBuffer(
-							this.#outputDir + "/nonexistent.txt",
-						);
-						assert.strictEqual(
-							result,
-							undefined,
-							"Expected undefined when reading a nonexistent file",
-						);
-					});
-
-					it("should return undefined when a file with the given file URL doesn't exist", async () => {
-						const result = await impl.arrayBuffer(
-							filePathToUrl(this.#outputDir + "/nonexistent.txt"),
-						);
-						assert.strictEqual(
-							result,
-							undefined,
-							"Expected undefined when reading a nonexistent file",
-						);
-					});
-				});
-			}
-
 			if (impl.bytes) {
 				describe("bytes()", () => {
 					it("should read a file and return the contents as an Uint8Array", async () => {
@@ -315,7 +186,8 @@ export class HfsImplTester {
 					await impl.write(filePath, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -326,7 +198,8 @@ export class HfsImplTester {
 					await impl.write(fileUrl, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -340,7 +213,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -355,7 +229,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -369,7 +244,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -384,7 +260,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -398,7 +275,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -413,7 +291,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -427,7 +306,8 @@ export class HfsImplTester {
 					await impl.write(filePath, bytes);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "o, ");
 				});
 
@@ -442,7 +322,8 @@ export class HfsImplTester {
 					await impl.write(fileUrl, bytes);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "o, ");
 				});
 
@@ -454,7 +335,8 @@ export class HfsImplTester {
 					await impl.write(filePath, "Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Goodbye, world!");
 				});
 
@@ -467,7 +349,8 @@ export class HfsImplTester {
 					await impl.write(fileUrl, "Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Goodbye, world!");
 				});
 
@@ -479,7 +362,8 @@ export class HfsImplTester {
 					await impl.write(filePath, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -492,7 +376,8 @@ export class HfsImplTester {
 					await impl.write(fileUrl, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 			});
@@ -514,7 +399,8 @@ export class HfsImplTester {
 					await impl.append(filePath, " Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -525,7 +411,8 @@ export class HfsImplTester {
 					await impl.append(fileUrl, " Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -542,7 +429,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -560,7 +448,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -577,7 +466,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -595,7 +485,8 @@ export class HfsImplTester {
 					);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -608,7 +499,8 @@ export class HfsImplTester {
 					await impl.append(filePath, bytes);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "o, ");
 				});
 
@@ -622,7 +514,8 @@ export class HfsImplTester {
 					await impl.append(fileUrl, bytes);
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "o, ");
 				});
 
@@ -633,7 +526,8 @@ export class HfsImplTester {
 					await impl.append(filePath, " Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -645,7 +539,8 @@ export class HfsImplTester {
 					await impl.append(fileUrl, " Goodbye, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world! Goodbye, world!");
 				});
 
@@ -657,7 +552,8 @@ export class HfsImplTester {
 					await impl.append(filePath, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -670,7 +566,8 @@ export class HfsImplTester {
 					await impl.append(fileUrl, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -679,7 +576,8 @@ export class HfsImplTester {
 					await impl.append(filePath, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 
@@ -690,7 +588,8 @@ export class HfsImplTester {
 					await impl.append(fileUrl, "Hello, world!");
 
 					// make sure the file was written
-					const result = await impl.text(filePath);
+					const resultBytes = await impl.bytes(filePath);
+					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Hello, world!");
 				});
 			});
@@ -1466,7 +1365,8 @@ export class HfsImplTester {
 							true,
 						);
 
-						const text = await impl.text(newFilePath);
+						const resultBytes = await impl.bytes(newFilePath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(text, "Hello, world!");
 					});
 
@@ -1483,7 +1383,8 @@ export class HfsImplTester {
 							true,
 						);
 
-						const text = await impl.text(newFilePath);
+						const resultBytes = await impl.bytes(newFilePath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(text, "Hello, world!");
 					});
 
@@ -1503,7 +1404,8 @@ export class HfsImplTester {
 							"File should exist at the new location.",
 						);
 
-						const text = await impl.text(newFilePath);
+						const resultBytes = await impl.bytes(newFilePath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(
 							text,
 							"Hello, world!",
@@ -1567,7 +1469,8 @@ export class HfsImplTester {
 						);
 						assert.strictEqual(await impl.isFile(destPath), true);
 
-						const text = await impl.text(destPath);
+						const resultBytes = await impl.bytes(destPath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(text, "Hello, world!");
 					});
 
@@ -1584,7 +1487,8 @@ export class HfsImplTester {
 						);
 						assert.strictEqual(await impl.isFile(destPath), true);
 
-						const text = await impl.text(destPath);
+						const resultBytes = await impl.bytes(destPath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(text, "Hello, world!");
 					});
 
@@ -1604,7 +1508,8 @@ export class HfsImplTester {
 							"File should exist at the new location.",
 						);
 
-						const text = await impl.text(destPath);
+						const resultBytes = await impl.bytes(destPath);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(
 							text,
 							"Hello, world!",
@@ -1637,7 +1542,10 @@ export class HfsImplTester {
 							"Directory should exist at the new location.",
 						);
 
-						const text = await impl.text(destPath + "/test3.txt");
+						const resultBytes = await impl.bytes(
+							destPath + "/test3.txt",
+						);
+						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(text, "Hello, world!"); //, "The file should contain the correct contents at the new location.");
 					});
 				});

--- a/packages/types/src/hfs-types.ts
+++ b/packages/types/src/hfs-types.ts
@@ -8,27 +8,6 @@
 //------------------------------------------------------------------------------
 
 export interface HfsImpl {
-	/**
-	 * Reads the given file and returns the contents as text. Assumes the file is UTF-8 encoded.
-	 * @param filePath The file to read.
-	 * @returns The contents of the file or undefined if the file is empty.
-	 */
-	text?(filePath: string|URL): Promise<string|undefined>;
-
-	/**
-	 * Reads the given file and returns the contents as JSON. Assumes the file is UTF-8 encoded.
-	 * @param filePath The file to read.
-	 * @returns The contents of the file as JSON or undefined if the file is empty.
-	 */
-	json?(filePath: string|URL): Promise<any|undefined>;
-
-	/**
-	 * Reads the given file and returns the contents as an ArrayBuffer.
-	 * @param filePath The file to read.
-	 * @returns The contents of the file as an ArrayBuffer or undefined if the file is empty.
-	 * @deprecated Use bytes() instead.
-	 */
-	arrayBuffer?(filePath: string|URL): Promise<ArrayBuffer|undefined>;
 
 	/**
 	 * Reads the given file and returns the contents as an Uint8Array.

--- a/packages/web/src/web-hfs.js
+++ b/packages/web/src/web-hfs.js
@@ -156,54 +156,6 @@ export class WebHfsImpl {
 	}
 
 	/**
-	 * Reads a file and returns the contents as a string. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<string|undefined>} A promise that resolves with the contents of
-	 *     the file or undefined if the file does not exist.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @throws {RangeError} If the file path is not absolute.
-	 * @throws {RangeError} If the file path is not a file.
-	 * @throws {RangeError} If the file path is not readable.
-	 */
-	async text(filePath) {
-		const text = /** @type {string|undefined} */ (
-			await readFile(this.#root, filePath, "text")
-		);
-		return text;
-	}
-
-	/**
-	 * Reads a file and returns the contents as a JSON object. Assumes UTF-8 encoding.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<object|null>} A promise that resolves with the contents of
-	 *    the file or undefined if the file does not exist.
-	 * @throws {SyntaxError} If the file contents are not valid JSON.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 */
-	async json(filePath) {
-		return this.text(filePath).then(text =>
-			text === undefined ? text : JSON.parse(text),
-		);
-	}
-
-	/**
-	 * Reads a file and returns the contents as an ArrayBuffer.
-	 * @param {string|URL} filePath The path to the file to read.
-	 * @returns {Promise<ArrayBuffer|undefined>} A promise that resolves with the contents
-	 *    of the file or undefined if the file does not exist.
-	 * @throws {Error} If the file cannot be read.
-	 * @throws {TypeError} If the file path is not a string.
-	 * @deprecated Use bytes() instead.
-	 */
-	async arrayBuffer(filePath) {
-		const buffer = /** @type {ArrayBuffer|undefined} */ (
-			await readFile(this.#root, filePath, "arrayBuffer")
-		);
-		return buffer;
-	}
-
-	/**
 	 * Reads a file and returns the contents as an Uint8Array.
 	 * @param {string|URL} filePath The path to the file to read.
 	 * @returns {Promise<Uint8Array|undefined>} A promise that resolves with the contents


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Make it so impls don't need to implement `text()`, `json()`, or `arrayBuffer()`. These methods now exist only on `Hfs` and impls need only implement `bytes()`.

## What changes did you make? (Give an overview)

* Removed `text()`, `json()`, and `arrayBuffer()` from all impls
* Removed associated tests from `HfsImplTester`
* Updated logic in `Hfs` to call `bytes()` for `text()`, `json()`, and `arrayBuffer()`

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
