### PR TITLE
feat: impl write() method only needs to handle Uint8Arrays

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,4 +1,18 @@
-# 2024-02-22 Impls only need to implements `bytes()` to read files.
+# 2024-02-22 Impls only need to implement `write()` and `append()` to accept `Uint8Array`.
+
+## Background
+
+Originally, impls needed to implement `write()` and `append()` to accept strings, `ArrayBuffer`s, and `ArrayBuffer` views.
+
+## Decision
+
+Impls need only implement `write()` and `append()` to accept `Uint8Array`; `Hfs` will ensure that any data that is passed to `write()` or `append()` is converted to a `Uint8Array` before passing the data to the impl.
+
+## Rationale
+
+Similar to the previous decision regarding `bytes()`, implementing `write()` and `append()` across impls revealed a lot of code duplication to validate and transform the input. The validation and transformation logic can more centrally be done in the `Hfs` class, making impl implementation simpler.
+
+# 2024-02-22 Impls only need to implement `bytes()` to read files
 
 ## Background
 

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -586,29 +586,29 @@ describe("Hfs", () => {
 		});
 	});
 
-	describe("write()", () => {
+	describe("append()", () => {
 		it("should not reject a promise when the value to write is a string", async () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
-			await hfs.write("/path/to/file.txt", "Hello, world!");
+			await hfs.append("/path/to/file.txt", "Hello, world!");
 		});
 
 		it("should not reject a promise when the value to write is an ArayBuffer", async () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
-			await hfs.write(
+			await hfs.append(
 				"/path/to/file.txt",
 				new Uint8Array([1, 2, 3]).buffer,
 			);
@@ -617,32 +617,32 @@ describe("Hfs", () => {
 		it("should not reject a promise when the value to write is a Uint8Array", async () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
-			await hfs.write("/path/to/file.txt", new Uint8Array([1, 2, 3]));
+			await hfs.append("/path/to/file.txt", new Uint8Array([1, 2, 3]));
 		});
 
 		it("should log the method call", async () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
-			hfs.logStart("write");
-			await hfs.write("/path/to/file.txt", "Hello, world!");
-			const logs = hfs.logEnd("write").map(normalizeLogEntry);
+			hfs.logStart("append");
+			await hfs.append("/path/to/file.txt", "Hello, world!");
+			const logs = hfs.logEnd("append").map(normalizeLogEntry);
 			assert.deepStrictEqual(logs, [
 				{
 					type: "call",
 					data: {
-						methodName: "write",
+						methodName: "append",
 						args: ["/path/to/file.txt", "Hello, world!"],
 					},
 				},
@@ -652,14 +652,14 @@ describe("Hfs", () => {
 		it("should reject a promise when the file path is not a string", () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
 			return assert.rejects(
-				hfs.write(123, "Hello, world!"),
+				hfs.append(123, "Hello, world!"),
 				new TypeError("Path must be a non-empty string or URL."),
 			);
 		});
@@ -667,14 +667,14 @@ describe("Hfs", () => {
 		it("should reject a promise when the file path is empty", () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
 			return assert.rejects(
-				hfs.write("", "Hello, world!"),
+				hfs.append("", "Hello, world!"),
 				new TypeError("Path must be a non-empty string or URL."),
 			);
 		});
@@ -682,17 +682,91 @@ describe("Hfs", () => {
 		it("should reject a promise when the contents are a number", () => {
 			const hfs = new Hfs({
 				impl: {
-					write() {
+					append() {
 						return undefined;
 					},
 				},
 			});
 
 			return assert.rejects(
-				hfs.write("/path/to/file.txt", 123),
+				hfs.append("/path/to/file.txt", 123),
 				new TypeError(
 					"File contents must be a string, ArrayBuffer, or ArrayBuffer view.",
 				),
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when text is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append("/path/to/file.txt", "Hello, world!");
+		});
+
+		it("should pass a Uint8Array to the impl method when an ArrayBuffer is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when a Uint8Array is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append("/path/to/file.txt", new Uint8Array([1, 2, 3]));
+		});
+
+		it("should pass a Uint8Array to the impl method when a DataView is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new DataView(new Uint8Array([1, 2, 3]).buffer),
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when a Uint8Array subarray is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+						assert.strictEqual(contents.byteLength, 2);
+						assert.deepStrictEqual(
+							contents,
+							new Uint8Array([2, 3]),
+						);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new Uint8Array([1, 2, 3]).subarray(1),
 			);
 		});
 	});
@@ -804,6 +878,80 @@ describe("Hfs", () => {
 				new TypeError(
 					"File contents must be a string, ArrayBuffer, or ArrayBuffer view.",
 				),
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when text is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append("/path/to/file.txt", "Hello, world!");
+		});
+
+		it("should pass a Uint8Array to the impl method when an ArrayBuffer is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when a Uint8Array is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append("/path/to/file.txt", new Uint8Array([1, 2, 3]));
+		});
+
+		it("should pass a Uint8Array to the impl method when a DataView is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new DataView(new Uint8Array([1, 2, 3]).buffer),
+			);
+		});
+
+		it("should pass a Uint8Array to the impl method when a Uint8Array subarray is passed", async () => {
+			const hfs = new Hfs({
+				impl: {
+					append(path, contents) {
+						assert.ok(contents instanceof Uint8Array);
+						assert.strictEqual(contents.byteLength, 2);
+						assert.deepStrictEqual(
+							contents,
+							new Uint8Array([2, 3]),
+						);
+					},
+				},
+			});
+
+			await hfs.append(
+				"/path/to/file.txt",
+				new Uint8Array([1, 2, 3]).subarray(1),
 			);
 		});
 	});

--- a/packages/deno/deno.lock
+++ b/packages/deno/deno.lock
@@ -136,5 +136,17 @@
     "https://deno.land/std@0.208.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
     "https://deno.land/std@0.208.0/testing/asserts.ts": "605bbd2ef0695e2a4324d810c4ad22e56041d51afb9584fc0b4e81084b14b1d6",
     "https://deno.land/std@0.208.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6"
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@humanwhocodes/retry@latest"
+    ],
+    "packageJson": {
+      "dependencies": [
+        "npm:@humanwhocodes/retry@^0.1.2",
+        "npm:@types/node@^20.9.4",
+        "npm:typescript@^5.2.2"
+      ]
+    }
   }
 }

--- a/packages/deno/src/deno-hfs.js
+++ b/packages/deno/src/deno-hfs.js
@@ -81,7 +81,7 @@ export class DenoHfsImpl {
 	 * Writes a value to a file, creating any necessary directories along the way.
 	 * If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to write.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to write to the
+	 * @param {Uint8Array} contents The contents to write to the
 	 *   file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 *  written.
@@ -89,32 +89,10 @@ export class DenoHfsImpl {
 	 * @throws {Error} If the file cannot be written.
 	 */
 	async write(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = contents;
-		} else if (contents instanceof Uint8Array) {
-			value = contents;
-		} else if (contents instanceof ArrayBuffer) {
-			value = new Uint8Array(contents);
-		} else if (ArrayBuffer.isView(contents)) {
-			const bytes = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-			value = new Uint8Array(bytes);
-		}
-
-		const op =
-			typeof value === "string"
-				? () =>
-						this.#deno.writeTextFile(filePath, value, {
-							create: true,
-						})
-				: () =>
-						this.#deno.writeFile(filePath, new Uint8Array(value), {
-							create: true,
-						});
+		const op = () =>
+			this.#deno.writeFile(filePath, contents, {
+				create: true,
+			});
 
 		return this.#retrier.retry(op).catch(error => {
 			if (error.code === "ENOENT") {
@@ -134,7 +112,7 @@ export class DenoHfsImpl {
 	/**
 	 * Appends a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to append to.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to append to the
+	 * @param {Uint8Array} contents The contents to append to the
 	 *  file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 * written.
@@ -142,32 +120,10 @@ export class DenoHfsImpl {
 	 * @throws {Error} If the file cannot be appended to.
 	 */
 	async append(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = contents;
-		} else if (contents instanceof Uint8Array) {
-			value = contents;
-		} else if (contents instanceof ArrayBuffer) {
-			value = new Uint8Array(contents);
-		} else if (ArrayBuffer.isView(contents)) {
-			const bytes = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-			value = new Uint8Array(bytes);
-		}
-
-		const op =
-			typeof value === "string"
-				? () =>
-						this.#deno.writeTextFile(filePath, value, {
-							append: true,
-						})
-				: () =>
-						this.#deno.writeFile(filePath, new Uint8Array(value), {
-							append: true,
-						});
+		const op = () =>
+			this.#deno.writeFile(filePath, contents, {
+				append: true,
+			});
 
 		return this.#retrier.retry(op).catch(error => {
 			if (error.code === "ENOENT") {

--- a/packages/deno/tests/deno-hfs.test.js
+++ b/packages/deno/tests/deno-hfs.test.js
@@ -33,6 +33,10 @@ const __filename = path.fromFileUrl(import.meta.url);
 const __dirname = path.dirname(__filename);
 const fixturesDir = path.resolve(__dirname, "fixtures");
 
+const encoder = new TextEncoder();
+const HELLO_WORLD = "Hello, world!";
+const HELLO_WORLD_BYTES = encoder.encode(HELLO_WORLD);
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -191,7 +195,7 @@ describe("DenoHfsImpl Customizations", () => {
 			let success = false;
 			const impl = new DenoHfsImpl({
 				deno: {
-					async writeTextFile() {
+					async writeFile() {
 						if (callCount === 0) {
 							callCount++;
 							const error = new Error(
@@ -206,7 +210,7 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			await impl.write(".hfs/foo", "Hello world!");
+			await impl.write(".hfs/foo", HELLO_WORLD_BYTES);
 			assert(success);
 		});
 
@@ -215,7 +219,7 @@ describe("DenoHfsImpl Customizations", () => {
 			let success = false;
 			const impl = new DenoHfsImpl({
 				deno: {
-					async writeTextFile() {
+					async writeFile() {
 						if (callCount === 0) {
 							callCount++;
 							const error = new Error(
@@ -230,7 +234,7 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			await impl.write(".hfs/foo", "Hello world!");
+			await impl.write(".hfs/foo", HELLO_WORLD_BYTES);
 			assert(success);
 		});
 
@@ -239,7 +243,7 @@ describe("DenoHfsImpl Customizations", () => {
 			let success = false;
 			const impl = new DenoHfsImpl({
 				deno: {
-					async writeTextFile() {
+					async writeFile() {
 						if (callCount < 3) {
 							callCount++;
 							const error = new Error(
@@ -254,20 +258,20 @@ describe("DenoHfsImpl Customizations", () => {
 				},
 			});
 
-			await impl.write(".hfs/foo", "Hello world!");
+			await impl.write(".hfs/foo", HELLO_WORLD_BYTES);
 			assert(success);
 		});
 
 		it("should rethrow an error that isn't ENFILE", async () => {
 			const impl = new DenoHfsImpl({
 				deno: {
-					async writeTextFile() {
+					async writeFile() {
 						throw new Error("Boom!");
 					},
 				},
 			});
 			await assertRejects(
-				() => impl.write(".hfs/foo", "Hello world!"),
+				() => impl.write(".hfs/foo", HELLO_WORLD_BYTES),
 				/Boom!/,
 			);
 		});

--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -2,7 +2,7 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global TextEncoder, URL */
+/* global URL */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -286,7 +286,7 @@ export class MemoryHfsImpl {
 	/**
 	 * Writes a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to write.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to write to the
+	 * @param {Uint8Array} contents The contents to write to the
 	 *   file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 *  written.
@@ -294,18 +294,10 @@ export class MemoryHfsImpl {
 	 * @throws {Error} If the file cannot be written.
 	 */
 	async write(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = new TextEncoder().encode(contents).buffer;
-		} else if (contents instanceof ArrayBuffer) {
-			value = contents;
-		} else if (ArrayBuffer.isView(contents)) {
-			value = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-		}
+		let value = contents.buffer.slice(
+			contents.byteOffset,
+			contents.byteOffset + contents.byteLength,
+		);
 
 		return writePath(this.#root, filePath, new MemoryHfsFile(value));
 	}
@@ -313,7 +305,7 @@ export class MemoryHfsImpl {
 	/**
 	 * Appends a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to append to.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to append to the
+	 * @param {Uint8Array} contents The contents to append to the
 	 *  file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 * written.
@@ -329,15 +321,10 @@ export class MemoryHfsImpl {
 			return this.write(filePath, contents);
 		}
 
-		const valueToAppend =
-			typeof contents === "string"
-				? new TextEncoder().encode(contents).buffer
-				: ArrayBuffer.isView(contents)
-					? contents.buffer.slice(
-							contents.byteOffset,
-							contents.byteOffset + contents.byteLength,
-						)
-					: contents;
+		const valueToAppend = contents.buffer.slice(
+			contents.byteOffset,
+			contents.byteOffset + contents.byteLength,
+		);
 
 		const newValue = new Uint8Array([
 			...new Uint8Array(existing.contents),

--- a/packages/memory/tests/memory-hfs.test.js
+++ b/packages/memory/tests/memory-hfs.test.js
@@ -40,7 +40,7 @@ describe("MemoryHfsImpl Customizations", () => {
 		// https://github.com/humanwhocodes/humanfs/issues/74
 		it("should delete a file that was just written at the root", async () => {
 			const impl = new MemoryHfsImpl();
-			await impl.write("foo.txt", "bar");
+			await impl.write("foo.txt", new Uint8Array([1, 2, 3]));
 			await impl.delete("foo.txt");
 			const result = await impl.isFile("foo.txt");
 			assert.strictEqual(result, false);

--- a/packages/node/src/node-hfs.js
+++ b/packages/node/src/node-hfs.js
@@ -129,7 +129,7 @@ export class NodeHfsImpl {
 	/**
 	 * Writes a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to write.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to write to the
+	 * @param {Uint8Array} contents The contents to write to the
 	 *   file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 *  written.
@@ -137,19 +137,7 @@ export class NodeHfsImpl {
 	 * @throws {Error} If the file cannot be written.
 	 */
 	async write(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = contents;
-		} else if (contents instanceof ArrayBuffer) {
-			value = Buffer.from(contents);
-		} else if (ArrayBuffer.isView(contents)) {
-			const bytes = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-			value = Buffer.from(bytes);
-		}
+		const value = Buffer.from(contents);
 
 		return this.#retrier
 			.retry(() => this.#fsp.writeFile(filePath, value))
@@ -174,7 +162,7 @@ export class NodeHfsImpl {
 	/**
 	 * Appends a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to append to.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to append to the
+	 * @param {Uint8Array} contents The contents to append to the
 	 *  file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 * written.
@@ -182,19 +170,7 @@ export class NodeHfsImpl {
 	 * @throws {Error} If the file cannot be appended to.
 	 */
 	async append(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = contents;
-		} else if (contents instanceof ArrayBuffer) {
-			value = Buffer.from(contents);
-		} else if (ArrayBuffer.isView(contents)) {
-			const bytes = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-			value = Buffer.from(bytes);
-		}
+		const value = Buffer.from(contents);
 
 		return this.#retrier
 			.retry(() => this.#fsp.appendFile(filePath, value))

--- a/packages/test/src/hfs-impl-tester.js
+++ b/packages/test/src/hfs-impl-tester.js
@@ -32,6 +32,15 @@
 // Helpers
 //-----------------------------------------------------------------------------
 
+const encoder = new TextEncoder();
+const HELLO_WORLD = "Hello, world!";
+const GOODBYE_WORLD = "Goodbye, world!";
+const HELLO_WORLD_BYTES = encoder.encode(HELLO_WORLD);
+const GOODBYE_WORLD_BYTES = encoder.encode(GOODBYE_WORLD);
+const HELLO_WORLD_JSON = encoder.encode(
+	JSON.stringify({ message: HELLO_WORLD }),
+);
+
 /**
  * Converts a file path into a URL with a file protocol. This first normalizes
  * the file path to use forward slashes and then creates a URL with the file
@@ -109,11 +118,11 @@ export class HfsImplTester {
 				await impl.createDirectory(this.#outputDir);
 				await impl.write(
 					this.#outputDir + "/hello.txt",
-					"Hello world!\n",
+					HELLO_WORLD_BYTES,
 				);
 				await impl.write(
 					this.#outputDir + "/message.json",
-					JSON.stringify({ message: "Hello world!" }),
+					HELLO_WORLD_JSON,
 				);
 			});
 
@@ -129,10 +138,7 @@ export class HfsImplTester {
 						const result = await impl.bytes(filePath);
 						assert.ok(result instanceof Uint8Array);
 						const decoder = new TextDecoder();
-						assert.strictEqual(
-							decoder.decode(result),
-							"Hello world!\n",
-						);
+						assert.strictEqual(decoder.decode(result), HELLO_WORLD);
 					});
 
 					it("should read a file and return the contents as an Uint8Array when using a file URL", async () => {
@@ -141,10 +147,7 @@ export class HfsImplTester {
 						const result = await impl.bytes(fileUrl);
 						assert.ok(result instanceof Uint8Array);
 						const decoder = new TextDecoder();
-						assert.strictEqual(
-							decoder.decode(result),
-							"Hello world!\n",
-						);
+						assert.strictEqual(decoder.decode(result), HELLO_WORLD);
 					});
 
 					it("should return undefined when a file doesn't exist", async () => {
@@ -180,73 +183,16 @@ export class HfsImplTester {
 					await impl.deleteAll(this.#outputDir + "/tmp-write");
 				});
 
-				it("should write a string to a file", async () => {
-					const filePath =
-						this.#outputDir + "/tmp-write/test-generated-text.txt";
-					await impl.write(filePath, "Hello, world!");
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
-				it("should write a string to a file URL", async () => {
-					const filePath =
-						this.#outputDir + "/tmp-write/test-generated-text.txt";
-					const fileUrl = filePathToUrl(filePath);
-					await impl.write(fileUrl, "Hello, world!");
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
-				it("should write an ArrayBuffer to a file", async () => {
-					const filePath =
-						this.#outputDir +
-						"/tmp-write/test-generated-arraybuffer.txt";
-					await impl.write(
-						filePath,
-						new TextEncoder().encode("Hello, world!").buffer,
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
-				it("should write an ArrayBuffer to a file URL", async () => {
-					const filePath =
-						this.#outputDir +
-						"/tmp-write/test-generated-arraybuffer.txt";
-					const fileUrl = filePathToUrl(filePath);
-					await impl.write(
-						fileUrl,
-						new TextEncoder().encode("Hello, world!").buffer,
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
 				it("should write a Uint8Array to a file", async () => {
 					const filePath =
 						this.#outputDir +
 						"/tmp-write/test-generated-arraybuffer.txt";
-					await impl.write(
-						filePath,
-						new TextEncoder().encode("Hello, world!"),
-					);
+					await impl.write(filePath, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should write a Uint8Array to a file URL", async () => {
@@ -254,55 +200,19 @@ export class HfsImplTester {
 						this.#outputDir +
 						"/tmp-write/test-generated-arraybuffer.txt";
 					const fileUrl = filePathToUrl(filePath);
-					await impl.write(
-						fileUrl,
-						new TextEncoder().encode("Hello, world!"),
-					);
+					await impl.write(fileUrl, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
-				it("should write a Uint8Array to a file", async () => {
-					const filePath =
-						this.#outputDir +
-						"/tmp-write/test-generated-arraybuffer.txt";
-					await impl.write(
-						filePath,
-						new TextEncoder().encode("Hello, world!"),
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
-				});
-
-				it("should write a Uint8Array to a file URL", async () => {
-					const filePath =
-						this.#outputDir +
-						"/tmp-write/test-generated-arraybuffer.txt";
-					const fileUrl = filePathToUrl(filePath);
-					await impl.write(
-						fileUrl,
-						new TextEncoder().encode("Hello, world!"),
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should write a Uint8Array subarray to a file", async () => {
 					const filePath =
 						this.#outputDir +
 						"/tmp-write/test-generated-arraybuffer.txt";
-					const bytes = new TextEncoder()
-						.encode("Hello, world!")
-						.subarray(4, 7);
+					const bytes = HELLO_WORLD_BYTES.subarray(4, 7);
 					await impl.write(filePath, bytes);
 
 					// make sure the file was written
@@ -316,9 +226,7 @@ export class HfsImplTester {
 						this.#outputDir +
 						"/tmp-write/test-generated-arraybuffer.txt";
 					const fileUrl = filePathToUrl(filePath);
-					const bytes = new TextEncoder()
-						.encode("Hello, world!")
-						.subarray(4, 7);
+					const bytes = HELLO_WORLD_BYTES.subarray(4, 7);
 					await impl.write(fileUrl, bytes);
 
 					// make sure the file was written
@@ -330,26 +238,26 @@ export class HfsImplTester {
 				it("should write to an already existing file", async () => {
 					const filePath =
 						this.#outputDir + "/tmp-write/test-generated-text.txt";
-					await impl.write(filePath, "Hello, world!");
 
-					await impl.write(filePath, "Goodbye, world!");
+					await impl.write(filePath, HELLO_WORLD_BYTES);
+					await impl.write(filePath, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Goodbye, world!");
+					assert.strictEqual(result, GOODBYE_WORLD);
 				});
 
 				it("should write to an already existing file URL", async () => {
 					const filePath =
 						this.#outputDir + "/tmp-write/test-generated-text.txt";
 					const fileUrl = filePathToUrl(filePath);
-					await impl.write(fileUrl, "Hello, world!");
 
-					await impl.write(fileUrl, "Goodbye, world!");
+					await impl.write(fileUrl, HELLO_WORLD_BYTES);
+					await impl.write(fileUrl, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
+					const resultBytes = await impl.bytes(fileUrl);
 					const result = new TextDecoder().decode(resultBytes);
 					assert.strictEqual(result, "Goodbye, world!");
 				});
@@ -359,12 +267,12 @@ export class HfsImplTester {
 						this.#outputDir +
 						"/tmp-write/nonexistent/test-generated-text.txt";
 
-					await impl.write(filePath, "Hello, world!");
+					await impl.write(filePath, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should write a file URL when the directory doesn't exist", async () => {
@@ -373,12 +281,12 @@ export class HfsImplTester {
 						"/tmp-write/nonexistent/test-generated-text.txt";
 					const fileUrl = filePathToUrl(filePath);
 
-					await impl.write(fileUrl, "Hello, world!");
+					await impl.write(fileUrl, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
+					const resultBytes = await impl.bytes(fileUrl);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 			});
 
@@ -393,108 +301,36 @@ export class HfsImplTester {
 					await impl.deleteAll(dirPath);
 				});
 
-				it("should append a string to a file", async () => {
-					const filePath = dirPath + "/test-generated-text.txt";
-					await impl.write(filePath, "Hello, world!");
-					await impl.append(filePath, " Goodbye, world!");
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
-				});
-
-				it("should append a string to a file URL", async () => {
-					const filePath = dirPath + "/test-generated-text.txt";
-					const fileUrl = filePathToUrl(filePath);
-					await impl.write(fileUrl, "Hello, world!");
-					await impl.append(fileUrl, " Goodbye, world!");
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
-				});
-
-				it("should append an ArrayBuffer to a file", async () => {
-					const filePath =
-						dirPath + "/test-generated-arraybuffer.txt";
-					await impl.write(
-						filePath,
-						new TextEncoder().encode("Hello, world!").buffer,
-					);
-					await impl.append(
-						filePath,
-						new TextEncoder().encode(" Goodbye, world!").buffer,
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
-				});
-
-				it("should append an ArrayBuffer to a file URL", async () => {
-					const filePath =
-						dirPath + "/test-generated-arraybuffer.txt";
-					const fileUrl = filePathToUrl(filePath);
-					await impl.write(
-						fileUrl,
-						new TextEncoder().encode("Hello, world!").buffer,
-					);
-					await impl.append(
-						fileUrl,
-						new TextEncoder().encode(" Goodbye, world!").buffer,
-					);
-
-					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
-					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
-				});
-
 				it("should append a Uint8Array to a file", async () => {
 					const filePath =
 						dirPath + "/test-generated-arraybuffer.txt";
-					await impl.write(
-						filePath,
-						new TextEncoder().encode("Hello, world!"),
-					);
-					await impl.append(
-						filePath,
-						new TextEncoder().encode(" Goodbye, world!"),
-					);
+					await impl.write(filePath, HELLO_WORLD_BYTES);
+					await impl.append(filePath, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
+					assert.strictEqual(result, HELLO_WORLD + GOODBYE_WORLD);
 				});
 
 				it("should append a Uint8Array to a file URL", async () => {
 					const filePath =
 						dirPath + "/test-generated-arraybuffer.txt";
 					const fileUrl = filePathToUrl(filePath);
-					await impl.write(
-						fileUrl,
-						new TextEncoder().encode("Hello, world!"),
-					);
-					await impl.append(
-						fileUrl,
-						new TextEncoder().encode(" Goodbye, world!"),
-					);
+					await impl.write(fileUrl, HELLO_WORLD_BYTES);
+					await impl.append(fileUrl, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
+					assert.strictEqual(result, HELLO_WORLD + GOODBYE_WORLD);
 				});
 
 				it("should append a Uint8Array subarray to a file", async () => {
 					const filePath =
 						dirPath + "/test-generated-arraybuffer.txt";
 					const bytes = new TextEncoder()
-						.encode("Hello, world! Goodbye, world!")
+						.encode(HELLO_WORLD + " " + GOODBYE_WORLD)
 						.subarray(4, 7);
 					await impl.append(filePath, bytes);
 
@@ -509,7 +345,7 @@ export class HfsImplTester {
 						dirPath + "/test-generated-arraybuffer.txt";
 					const fileUrl = filePathToUrl(filePath);
 					const bytes = new TextEncoder()
-						.encode("Hello, world! Goodbye, world!")
+						.encode(HELLO_WORLD + " " + GOODBYE_WORLD)
 						.subarray(4, 7);
 					await impl.append(fileUrl, bytes);
 
@@ -521,27 +357,26 @@ export class HfsImplTester {
 
 				it("should append to an already existing file", async () => {
 					const filePath = dirPath + "/test-generated-text.txt";
-					await impl.write(filePath, "Hello, world!");
 
-					await impl.append(filePath, " Goodbye, world!");
+					await impl.append(filePath, HELLO_WORLD_BYTES);
+					await impl.append(filePath, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
+					assert.strictEqual(result, HELLO_WORLD + GOODBYE_WORLD);
 				});
 
 				it("should append to an already existing file URL", async () => {
 					const filePath = dirPath + "/test-generated-text.txt";
 					const fileUrl = filePathToUrl(filePath);
-					await impl.write(fileUrl, "Hello, world!");
-
-					await impl.append(fileUrl, " Goodbye, world!");
+					await impl.append(fileUrl, HELLO_WORLD_BYTES);
+					await impl.append(fileUrl, GOODBYE_WORLD_BYTES);
 
 					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
+					const resultBytes = await impl.bytes(fileUrl);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world! Goodbye, world!");
+					assert.strictEqual(result, HELLO_WORLD + GOODBYE_WORLD);
 				});
 
 				it("should append to a file when the directory doesn't exist", async () => {
@@ -549,12 +384,12 @@ export class HfsImplTester {
 						this.#outputDir +
 						"/tmp-append/nonexistent/test-generated-text.txt";
 
-					await impl.append(filePath, "Hello, world!");
+					await impl.append(filePath, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should append to a file URL when the directory doesn't exist", async () => {
@@ -563,34 +398,35 @@ export class HfsImplTester {
 						"/tmp-append/nonexistent/test-generated-text.txt";
 					const fileUrl = filePathToUrl(filePath);
 
-					await impl.append(fileUrl, "Hello, world!");
+					await impl.append(fileUrl, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
+					const resultBytes = await impl.bytes(fileUrl);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should create a file when the file doesn't exist", async () => {
 					const filePath = dirPath + "/test-generated-text.txt";
-					await impl.append(filePath, "Hello, world!");
+
+					await impl.append(filePath, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
 					const resultBytes = await impl.bytes(filePath);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 
 				it("should create a file when the file URL doesn't exist", async () => {
 					const filePath = dirPath + "/test-generated-text.txt";
 					const fileUrl = filePathToUrl(filePath);
 
-					await impl.append(fileUrl, "Hello, world!");
+					await impl.append(fileUrl, HELLO_WORLD_BYTES);
 
 					// make sure the file was written
-					const resultBytes = await impl.bytes(filePath);
+					const resultBytes = await impl.bytes(fileUrl);
 					const result = new TextDecoder().decode(resultBytes);
-					assert.strictEqual(result, "Hello, world!");
+					assert.strictEqual(result, HELLO_WORLD);
 				});
 			});
 
@@ -741,7 +577,7 @@ export class HfsImplTester {
 						);
 						await impl.write(
 							dirPath + "/subdir/subsubdir/test.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 					});
 
@@ -831,7 +667,7 @@ export class HfsImplTester {
 					await impl.createDirectory(dirPath + "/subdir/subsubdir");
 					await impl.write(
 						dirPath + "/subdir/subsubdir/test.txt",
-						"Hello, world!",
+						HELLO_WORLD_BYTES,
 					);
 				});
 
@@ -929,11 +765,11 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 
 						const result = await impl.list(dirPath);
@@ -945,11 +781,11 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 
 						const dirUrl = filePathToUrl(dirPath);
@@ -972,11 +808,11 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						const result = [];
 
@@ -1025,11 +861,11 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						const dirUrl = filePathToUrl(dirPath);
 						const result = [];
@@ -1160,7 +996,7 @@ export class HfsImplTester {
 						);
 						await impl.write(
 							dirPath + "/subdir/subsubdir/test.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 					});
 
@@ -1260,7 +1096,7 @@ export class HfsImplTester {
 						);
 						await impl.write(
 							dirPath + "/subdir/subsubdir/test.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 					});
 
@@ -1342,11 +1178,11 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 					});
 
@@ -1367,7 +1203,7 @@ export class HfsImplTester {
 
 						const resultBytes = await impl.bytes(newFilePath);
 						const text = new TextDecoder().decode(resultBytes);
-						assert.strictEqual(text, "Hello, world!");
+						assert.strictEqual(text, HELLO_WORLD);
 					});
 
 					it("should move a file at the file URL", async () => {
@@ -1385,7 +1221,7 @@ export class HfsImplTester {
 
 						const resultBytes = await impl.bytes(newFilePath);
 						const text = new TextDecoder().decode(resultBytes);
-						assert.strictEqual(text, "Hello, world!");
+						assert.strictEqual(text, HELLO_WORLD);
 					});
 
 					it("should move a file to a new directory", async () => {
@@ -1408,7 +1244,7 @@ export class HfsImplTester {
 						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(
 							text,
-							"Hello, world!",
+							HELLO_WORLD,
 							"The file should contain the correct contents at the new location.",
 						);
 					});
@@ -1442,15 +1278,15 @@ export class HfsImplTester {
 						await impl.createDirectory(dirPath + "/subdir");
 						await impl.write(
 							dirPath + "/test1.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/test2.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 						await impl.write(
 							dirPath + "/subdir/test3.txt",
-							"Hello, world!",
+							HELLO_WORLD_BYTES,
 						);
 					});
 
@@ -1471,7 +1307,7 @@ export class HfsImplTester {
 
 						const resultBytes = await impl.bytes(destPath);
 						const text = new TextDecoder().decode(resultBytes);
-						assert.strictEqual(text, "Hello, world!");
+						assert.strictEqual(text, HELLO_WORLD);
 					});
 
 					it("should move a file at the file URL", async () => {
@@ -1489,7 +1325,7 @@ export class HfsImplTester {
 
 						const resultBytes = await impl.bytes(destPath);
 						const text = new TextDecoder().decode(resultBytes);
-						assert.strictEqual(text, "Hello, world!");
+						assert.strictEqual(text, HELLO_WORLD);
 					});
 
 					it("should move a file to a new directory", async () => {
@@ -1512,7 +1348,7 @@ export class HfsImplTester {
 						const text = new TextDecoder().decode(resultBytes);
 						assert.strictEqual(
 							text,
-							"Hello, world!",
+							HELLO_WORLD,
 							"The file should contain the correct contents at the new location.",
 						);
 					});
@@ -1546,7 +1382,7 @@ export class HfsImplTester {
 							destPath + "/test3.txt",
 						);
 						const text = new TextDecoder().decode(resultBytes);
-						assert.strictEqual(text, "Hello, world!"); //, "The file should contain the correct contents at the new location.");
+						assert.strictEqual(text, HELLO_WORLD); //, "The file should contain the correct contents at the new location.");
 					});
 				});
 			}

--- a/packages/types/src/hfs-types.ts
+++ b/packages/types/src/hfs-types.ts
@@ -23,7 +23,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the file is written.
 	 * @throws {Error} If the file cannot be written.
 	 */
-	write?(filePath: string|URL, data: string|ArrayBuffer|ArrayBufferView): Promise<void>;
+	write?(filePath: string|URL, data: Uint8Array): Promise<void>;
 
 	/**
 	 * Appends the given data to the given file. For text, assumes UTF-8 encoding.
@@ -32,7 +32,7 @@ export interface HfsImpl {
 	 * @returns A promise that resolves when the file is written.
 	 * @throws {Error} If the file cannot be written.
 	 */
-	append?(filePath: string|URL, data: string|ArrayBuffer|ArrayBufferView): Promise<void>;
+	append?(filePath: string|URL, data: Uint8Array): Promise<void>;
 
 	/**
 	 * Checks if the given file exists.

--- a/packages/web/src/web-hfs.js
+++ b/packages/web/src/web-hfs.js
@@ -187,11 +187,6 @@ export class WebHfsImpl {
 	 * @throws {Error} If the file cannot be written.
 	 */
 	async write(filePath, contents) {
-		let value = contents.buffer.slice(
-			contents.byteOffset,
-			contents.byteOffset + contents.byteLength,
-		);
-
 		let handle = /** @type {FileSystemFileHandle} */ (
 			await findPath(this.#root, filePath)
 		);
@@ -214,7 +209,7 @@ export class WebHfsImpl {
 		}
 
 		const writable = await handle.createWritable();
-		await writable.write(value);
+		await writable.write(contents);
 		await writable.close();
 	}
 
@@ -244,19 +239,9 @@ export class WebHfsImpl {
 		}
 
 		const existing = await (await handle.getFile()).arrayBuffer();
-
-		// contents must be an ArrayBuffer or ArrayBufferView
-
-		const valueToAppend = /** @type {ArrayBuffer} */ (
-			contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			)
-		);
-
 		const newValue = new Uint8Array([
 			...new Uint8Array(existing),
-			...new Uint8Array(valueToAppend),
+			...contents,
 		]);
 
 		return this.write(filePath, newValue);

--- a/packages/web/src/web-hfs.js
+++ b/packages/web/src/web-hfs.js
@@ -2,7 +2,7 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global navigator, URL, TextEncoder */
+/* global navigator, URL */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -179,7 +179,7 @@ export class WebHfsImpl {
 	/**
 	 * Writes a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to write.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to write to the
+	 * @param {Uint8Array} contents The contents to write to the
 	 *   file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 *  written.
@@ -187,18 +187,10 @@ export class WebHfsImpl {
 	 * @throws {Error} If the file cannot be written.
 	 */
 	async write(filePath, contents) {
-		let value;
-
-		if (typeof contents === "string") {
-			value = contents;
-		} else if (contents instanceof ArrayBuffer) {
-			value = contents;
-		} else if (ArrayBuffer.isView(contents)) {
-			value = contents.buffer.slice(
-				contents.byteOffset,
-				contents.byteOffset + contents.byteLength,
-			);
-		}
+		let value = contents.buffer.slice(
+			contents.byteOffset,
+			contents.byteOffset + contents.byteLength,
+		);
 
 		let handle = /** @type {FileSystemFileHandle} */ (
 			await findPath(this.#root, filePath)
@@ -229,7 +221,7 @@ export class WebHfsImpl {
 	/**
 	 * Appends a value to a file. If the value is a string, UTF-8 encoding is used.
 	 * @param {string|URL} filePath The path to the file to append to.
-	 * @param {string|ArrayBuffer|ArrayBufferView} contents The contents to append to the
+	 * @param {Uint8Array} contents The contents to append to the
 	 *  file.
 	 * @returns {Promise<void>} A promise that resolves when the file is
 	 * written.
@@ -256,20 +248,16 @@ export class WebHfsImpl {
 		// contents must be an ArrayBuffer or ArrayBufferView
 
 		const valueToAppend = /** @type {ArrayBuffer} */ (
-			ArrayBuffer.isView(contents)
-				? contents.buffer.slice(
-						contents.byteOffset,
-						contents.byteOffset + contents.byteLength,
-					)
-				: typeof contents === "string"
-					? new TextEncoder().encode(contents).buffer
-					: contents
+			contents.buffer.slice(
+				contents.byteOffset,
+				contents.byteOffset + contents.byteLength,
+			)
 		);
 
 		const newValue = new Uint8Array([
 			...new Uint8Array(existing),
 			...new Uint8Array(valueToAppend),
-		]).buffer;
+		]);
 
 		return this.write(filePath, newValue);
 	}


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Changes `Hfs` so that impl `write()` methods only need to accept `Uint8Array` values.

## What changes did you make? (Give an overview)

- Updated `Hfs` to convert text and ArrayBuffer views into `Uint8Array`s
- Updated `Hfs` tests
- Updated each runtime package
- Removed tests from `HfsImplTester` related to other data types

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
