### PR TITLE
feat: Add from() to Path; deprecate fromString() and fromURL()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8432,7 +8432,7 @@
         "@humanwhocodes/retry": "^0.1.2"
       },
       "devDependencies": {
-        "@types/node": "^20.11.20",
+        "@types/node": "^20.9.4",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -8449,7 +8449,7 @@
       "devDependencies": {
         "@humanfs/test": "^0.12.0",
         "@humanfs/types": "^0.11.0",
-        "@types/node": "^20.11.20",
+        "@types/node": "^20.9.4",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       },
@@ -8468,7 +8468,7 @@
       "devDependencies": {
         "@humanfs/test": "^0.12.0",
         "@humanfs/types": "^0.11.0",
-        "@types/node": "^20.11.20",
+        "@types/node": "^20.9.4",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
       },

--- a/packages/core/src/path.js
+++ b/packages/core/src/path.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/* globals URL */
+
 //-----------------------------------------------------------------------------
 // Types
 //-----------------------------------------------------------------------------
@@ -117,11 +119,19 @@ export class Path {
 	}
 
 	/**
+	 * Returns an iterator for steps in the path.
+	 * @returns {IterableIterator<string>} An iterator for the steps in the path.
+	 */
+	steps() {
+		return this.#steps.values();
+	}
+
+	/**
 	 * Returns an iterator for the steps in the path.
 	 * @returns {IterableIterator<string>} An iterator for the steps in the path.
 	 */
 	[Symbol.iterator]() {
-		return this.#steps.values();
+		return this.steps();
 	}
 
 	/**
@@ -158,9 +168,42 @@ export class Path {
 	}
 
 	/**
+	 * Creates a new path based on the argument type. If the argument is a string,
+	 * it is assumed to be a file or directory path and is converted to a Path
+	 * instance. If the argument is a URL, it is assumed to be a file URL and is
+	 * converted to a Path instance. If the argument is a Path instance, it is
+	 * copied into a new Path instance. If the argument is an array, it is assumed
+	 * to be the steps of a path and is used to create a new Path instance.
+	 * @param {string|URL|Path|Array<string>} pathish The value to convert to a Path instance.
+	 * @returns {Path} A new Path instance.
+	 * @throws {TypeError} When pathish is not a string, URL, Path, or Array.
+	 * @throws {TypeError} When pathish is a string and is empty.
+	 */
+	static from(pathish) {
+		if (typeof pathish === "string") {
+			if (!pathish) {
+				throw new TypeError("argument cannot be empty");
+			}
+
+			return Path.fromString(pathish);
+		}
+
+		if (pathish instanceof URL) {
+			return Path.fromURL(pathish);
+		}
+
+		if (pathish instanceof Path || Array.isArray(pathish)) {
+			return new Path(pathish);
+		}
+
+		throw new TypeError("argument must be a string, URL, Path, or Array");
+	}
+
+	/**
 	 * Creates a new Path instance from a string.
 	 * @param {string} fileOrDirPath The file or directory path to convert.
 	 * @returns {Path} A new Path instance.
+	 * @deprecated Use Path.from() instead.
 	 */
 	static fromString(fileOrDirPath) {
 		return new Path(normalizePath(fileOrDirPath).split("/"));
@@ -173,6 +216,7 @@ export class Path {
 	 * @throws {TypeError} When url is not a URL instance.
 	 * @throws {TypeError} When url.pathname is empty.
 	 * @throws {TypeError} When url.protocol is not "file:".
+	 * @deprecated Use Path.from() instead.
 	 */
 	static fromURL(url) {
 		if (!(url instanceof URL)) {

--- a/packages/core/tests/path.test.js
+++ b/packages/core/tests/path.test.js
@@ -2,7 +2,7 @@
  * @fileoverview Tests for the Path class.
  * @author Nicholas C. Zakas
  */
-/* global it, describe */
+/* global it, describe, URL */
 
 //------------------------------------------------------------------------------
 // Imports
@@ -363,32 +363,78 @@ describe("Path", () => {
 
 		it("should throw a TypeError when the URL is not a URL instance", () => {
 			const invalidUrl = "file:///c:/foo/bar";
-			assert.throws(
-				() => {
-					Path.fromURL(invalidUrl);
-				},
-				new TypeError("url must be a URL instance")
-			);
+			assert.throws(() => {
+				Path.fromURL(invalidUrl);
+			}, new TypeError("url must be a URL instance"));
 		});
 
 		it("should throw a TypeError when the URL pathname is empty", () => {
 			const url = new URL("file:///");
-			assert.throws(
-				() => {
-					Path.fromURL(url);
-				},
-				new TypeError("url.pathname cannot be empty")
-			);
+			assert.throws(() => {
+				Path.fromURL(url);
+			}, new TypeError("url.pathname cannot be empty"));
 		});
 
 		it("should throw a TypeError when the URL protocol is not 'file:'", () => {
 			const url = new URL("http://example.com/foo/bar");
-			assert.throws(
-				() => {
-					Path.fromURL(url);
-				},
-				new TypeError("url.protocol must be \"file:\"")
-			);
+			assert.throws(() => {
+				Path.fromURL(url);
+			}, new TypeError('url.protocol must be "file:"'));
+		});
+	});
+
+	describe("static from()", () => {
+		describe("string arguments", () => {
+			it("should create a new Path instance from a string", () => {
+				const path = Path.from("foo/bar");
+				assert.deepStrictEqual([...path], ["foo", "bar"]);
+			});
+
+			it("should throw a TypeError when the string is empty", () => {
+				assert.throws(() => {
+					Path.from("");
+				}, new TypeError("argument cannot be empty"));
+			});
+		});
+
+		describe("URL arguments", () => {
+			it("should create a new Path instance from a valid URL", () => {
+				const url = new URL("file:///c:/foo/bar");
+				const path = Path.from(url);
+				assert.deepStrictEqual([...path], ["foo", "bar"]);
+			});
+
+			it("should throw a TypeError when the URL pathname is empty", () => {
+				const url = new URL("file:///");
+				assert.throws(() => {
+					Path.from(url);
+				}, new TypeError("url.pathname cannot be empty"));
+			});
+
+			it("should throw a TypeError when the URL protocol is not 'file:'", () => {
+				const url = new URL("http://example.com/foo/bar");
+				assert.throws(() => {
+					Path.from(url);
+				}, new TypeError('url.protocol must be "file:"'));
+			});
+		});
+
+		describe("Path arguments", () => {
+			it("should create a new Path instance from a Path instance", () => {
+				const originalPath = new Path(["foo", "bar"]);
+				const path = Path.from(originalPath);
+				assert.ok(path instanceof Path);
+				assert.deepStrictEqual([...path], ["foo", "bar"]);
+				assert.notStrictEqual(path, originalPath);
+			});
+		});
+
+		describe("Array arguments", () => {
+			it("should create a new Path instance from an array of steps", () => {
+				const path = Path.from(["foo", "bar"]);
+				assert.ok(path instanceof Path);
+				assert.deepStrictEqual([...path], ["foo", "bar"]);
+			});
 		});
 	});
 });

--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -2,7 +2,6 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global URL */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -46,10 +45,7 @@ function assertArrayBuffer(value) {
  * @returns {{object:object,key:string}|undefined} The file or directory found.
  */
 function findPath(volume, fileOrDirPath) {
-	const path =
-		fileOrDirPath instanceof URL
-			? Path.fromURL(fileOrDirPath)
-			: Path.fromString(fileOrDirPath);
+	const path = Path.from(fileOrDirPath);
 	const parts = [...path];
 
 	let object = volume;
@@ -92,10 +88,7 @@ function readPath(volume, fileOrDirPath) {
  * @returns {void}
  */
 function writePath(volume, fileOrDirPath, value) {
-	const path =
-		fileOrDirPath instanceof URL
-			? Path.fromURL(fileOrDirPath)
-			: Path.fromString(fileOrDirPath);
+	const path = Path.from(fileOrDirPath);
 	const name = path.pop();
 	let directory = volume;
 
@@ -546,15 +539,8 @@ export class MemoryHfsImpl {
 			throw new NotFoundError(`copyAll '${source}' -> '${destination}'`);
 		}
 
-		const sourcePath =
-			source instanceof URL
-				? Path.fromURL(source)
-				: Path.fromString(source);
-
-		const destinationPath =
-			destination instanceof URL
-				? Path.fromURL(destination)
-				: Path.fromString(destination);
+		const sourcePath = Path.from(source);
+		const destinationPath = Path.from(destination);
 
 		// for directories, create the destination directory and copy each entry
 		await this.createDirectory(destination);
@@ -625,15 +611,8 @@ export class MemoryHfsImpl {
 			throw new NotFoundError(`moveAll '${source}' -> '${destination}'`);
 		}
 
-		const sourcePath =
-			source instanceof URL
-				? Path.fromURL(source)
-				: Path.fromString(source);
-
-		const destinationPath =
-			destination instanceof URL
-				? Path.fromURL(destination)
-				: Path.fromString(destination);
+		const sourcePath = Path.from(source);
+		const destinationPath = Path.from(destination);
 
 		// for directories, create the destination directory and copy each entry
 		await this.createDirectory(destination);

--- a/packages/web/src/web-hfs.js
+++ b/packages/web/src/web-hfs.js
@@ -2,7 +2,7 @@
  * @fileoverview The main file for the hfs package.
  * @author Nicholas C. Zakas
  */
-/* global navigator, URL */
+/* global navigator */
 
 //-----------------------------------------------------------------------------
 // Types
@@ -49,11 +49,7 @@ async function findPath(
 		return root;
 	}
 
-	const path =
-		fileOrDirPath instanceof URL
-			? Path.fromURL(fileOrDirPath)
-			: Path.fromString(fileOrDirPath);
-
+	const path = Path.from(fileOrDirPath);
 	const steps = [...path];
 
 	if (returnParent) {
@@ -192,10 +188,7 @@ export class WebHfsImpl {
 		);
 
 		if (!handle) {
-			const path =
-				filePath instanceof URL
-					? Path.fromURL(filePath)
-					: Path.fromString(filePath);
+			const path = Path.from(filePath);
 			const name = path.name;
 			const parentHandle =
 				/** @type {FileSystemDirectoryHandle} */ (
@@ -279,10 +272,7 @@ export class WebHfsImpl {
 	 */
 	async createDirectory(dirPath) {
 		let handle = this.#root;
-		const path =
-			dirPath instanceof URL
-				? Path.fromURL(dirPath)
-				: Path.fromString(dirPath);
+		const path = Path.from(dirPath);
 
 		for (const name of path) {
 			handle = await handle.getDirectoryHandle(name, { create: true });
@@ -445,10 +435,7 @@ export class WebHfsImpl {
 
 		// @ts-ignore -- TS doesn't know about this yet
 		for await (const entry of this.list(fileOrDirPath)) {
-			const entryPath =
-				fileOrDirPath instanceof URL
-					? Path.fromURL(fileOrDirPath)
-					: Path.fromString(fileOrDirPath);
+			const entryPath = Path.from(fileOrDirPath);
 			entryPath.push(entry.name);
 
 			const date = await this.lastModified(entryPath.toString());
@@ -521,15 +508,8 @@ export class WebHfsImpl {
 			throw new NotFoundError(`copyAll '${source}' -> '${destination}'`);
 		}
 
-		const sourcePath =
-			source instanceof URL
-				? Path.fromURL(source)
-				: Path.fromString(source);
-
-		const destinationPath =
-			destination instanceof URL
-				? Path.fromURL(destination)
-				: Path.fromString(destination);
+		const sourcePath = Path.from(source);
+		const destinationPath = Path.from(destination);
 
 		// for directories, create the destination directory and copy each entry
 		await this.createDirectory(destination);
@@ -575,10 +555,7 @@ export class WebHfsImpl {
 		}
 
 		const fileHandle = /** @type {FileSystemFileHandle} */ (handle);
-		const destinationPath =
-			destination instanceof URL
-				? Path.fromURL(destination)
-				: Path.fromString(destination);
+		const destinationPath = Path.from(destination);
 		const destinationName = destinationPath.pop();
 		const destinationParent = await findPath(
 			this.#root,
@@ -627,10 +604,7 @@ export class WebHfsImpl {
 		const directoryHandle = /** @type {FileSystemDirectoryHandle} */ (
 			handle
 		);
-		const destinationPath =
-			destination instanceof URL
-				? Path.fromURL(destination)
-				: Path.fromString(destination);
+		const destinationPath = Path.from(destination);
 
 		// Chrome doesn't yet support move() on directories
 		// @ts-ignore -- TS doesn't know about this yet
@@ -646,10 +620,7 @@ export class WebHfsImpl {
 			return directoryHandle.move(destinationParent, destinationName);
 		}
 
-		const sourcePath =
-			source instanceof URL
-				? Path.fromURL(source)
-				: Path.fromString(source);
+		const sourcePath = Path.from(source);
 
 		// for directories, create the destination directory and move each entry
 		await this.createDirectory(destination);


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Adds `Path.from()` and switches impls to use it

## What changes did you make? (Give an overview)

 - Added `Path.from()`
 - Deprecated `Path.fromString()` and `Path.fromURL()`
 - Switched web and memory impls to use `Path.from()`
 - Added tests for `Path.from()`

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
