### PR TITLE
feat!: delete/deleteAll should not throw on ENOENT

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,3 +1,21 @@
+# 2024-03-19 `delete()` and `deleteAll()` should not throw errors on missing items
+
+## Background
+
+Most of the runtime APIs for files throw an error when you attempt to delete a file that doesn't exist (an `ENOENT` error).
+
+## Decision
+
+The `delete()` and `deleteAll()` methods should not throw an error when the specified path doesn't exist. They should return `false` in that case, or `true` if the path did exist and wasn't deleted.
+
+## Rationale
+
+In most cases, humanfs suppresses `ENOENT` errors but didn't with `delete()` and `deleteAll()`. Logically, you typically only care that the specified path no longer exists, not whether it actually existed in the first place. If you actually care about that, then checking the return value of `delete()` and `deleteAll()` is a nicer way to handle it.
+
+## Related
+
+* https://github.com/humanwhocodes/humanfs/discussions/104
+
 # 2024-02-22 Impls only need to implement `write()` and `append()` to accept `Uint8Array`.
 
 ## Background

--- a/docs/directory-operations.md
+++ b/docs/directory-operations.md
@@ -48,7 +48,15 @@ await hfs.moveAll("/path/to/source", "/path/to/destination");
 To delete an empty directory, call the `hfs.delete(dirPath)` method. For example:
 
 ```js
-await hfs.delete("/path/to/directories");
+await hfs.delete("/path/to/directory");
+```
+
+This method doesn't throw an error if the path doesn't exist. If you want to know whether or not an existing file was deleted, you can use the return value: `true` if the file was actually deleted or `false` if the file didn't exist:
+
+```js
+if (await hfs.delete("/path/to/directory")) {
+	console.log("Directory existed and was deleted.");
+}
 ```
 
 To delete a non-empty directory recursively, call the `hfs.deleteAll(dirPath)` method. For example:
@@ -56,6 +64,8 @@ To delete a non-empty directory recursively, call the `hfs.deleteAll(dirPath)` m
 ```js
 await hfs.deleteAll("/path/to/directories");
 ```
+
+This method also returns a boolean indicating if the directory existed or not.
 
 > [!IMPORTANT]
 > The `deleteAll()` method acts like `rm -rf`, so it will delete directories that aren't empty. Use with caution.

--- a/docs/file-operations.md
+++ b/docs/file-operations.md
@@ -112,6 +112,14 @@ To delete files, call the `hfs.delete(filePath)` method. For example:
 await hfs.delete("/path/to/file.txt");
 ```
 
+This method doesn't throw an error if the path doesn't exist. If you want to know whether or not an existing file was deleted, you can use the return value: `true` if the file was actually deleted or `false` if the file didn't exist:
+
+```js
+if (await hfs.delete("/path/to/file.txt")) {
+	console.log("File existed and was deleted.");
+}
+```
+
 ## Retrieving File Size
 
 To get the size of a file in bytes, call the `hfs.size(filePath)` method. This method returns the size in bytes of the file if found and `undefined` if not found. Here's an example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8415,7 +8415,7 @@
       "version": "0.16.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@humanfs/types": "^0.11.0",
+        "@humanfs/types": "^0.12.0",
         "c8": "^9.0.0",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
@@ -8447,8 +8447,8 @@
         "@humanfs/core": "^0.16.1"
       },
       "devDependencies": {
-        "@humanfs/test": "^0.12.0",
-        "@humanfs/types": "^0.11.0",
+        "@humanfs/test": "^0.13.0",
+        "@humanfs/types": "^0.12.0",
         "@types/node": "^20.9.4",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
@@ -8466,8 +8466,8 @@
         "@humanwhocodes/retry": "^0.1.2"
       },
       "devDependencies": {
-        "@humanfs/test": "^0.12.0",
-        "@humanfs/types": "^0.11.0",
+        "@humanfs/test": "^0.13.0",
+        "@humanfs/types": "^0.12.0",
         "@types/node": "^20.9.4",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
@@ -8478,7 +8478,7 @@
     },
     "packages/test": {
       "name": "@humanfs/test",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.2.2"
@@ -8489,7 +8489,7 @@
     },
     "packages/types": {
       "name": "@humanfs/types",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.2.2"
@@ -8506,8 +8506,8 @@
         "@humanfs/core": "^0.16.1"
       },
       "devDependencies": {
-        "@humanfs/test": "^0.12.0",
-        "@humanfs/types": "^0.11.0",
+        "@humanfs/test": "^0.13.0",
+        "@humanfs/types": "^0.12.0",
         "@wdio/browser-runner": "^8.29.1",
         "@wdio/cli": "^8.29.1",
         "@wdio/mocha-framework": "^8.29.1",

--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -473,9 +473,11 @@ export class Hfs {
 	}
 
 	/**
-	 * Deletes the given file.
+	 * Deletes the given file or empty directory.
 	 * @param {string|URL} filePath The file to delete.
-	 * @returns {Promise<void>} A promise that resolves when the file is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the file path is not a non-empty string.
 	 */
@@ -485,9 +487,11 @@ export class Hfs {
 	}
 
 	/**
-	 * Deletes the given directory.
+	 * Deletes the given file or directory recursively.
 	 * @param {string|URL} dirPath The directory to delete.
-	 * @returns {Promise<void>} A promise that resolves when the directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {NoSuchMethodError} When the method does not exist on the current implementation.
 	 * @throws {TypeError} When the directory path is not a non-empty string.
 	 */

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -1250,6 +1250,32 @@ describe("Hfs", () => {
 				new TypeError("Path must be a non-empty string or URL."),
 			);
 		});
+
+		it("should return true when the impl method returns true", async () => {
+			const hfs = new Hfs({
+				impl: {
+					delete() {
+						return true;
+					},
+				},
+			});
+
+			const result = await hfs.delete("/path/to/file.txt");
+			assert.strictEqual(result, true);
+		});
+
+		it("should return false when the impl method returns false", async () => {
+			const hfs = new Hfs({
+				impl: {
+					delete() {
+						return false;
+					},
+				},
+			});
+
+			const result = await hfs.delete("/path/to/file.txt");
+			assert.strictEqual(result, false);
+		});
 	});
 
 	describe("deleteAll()", () => {
@@ -1316,6 +1342,32 @@ describe("Hfs", () => {
 				hfs.deleteAll(""),
 				/Path must be a non-empty string./,
 			);
+		});
+
+		it("should return true when the impl method returns true", async () => {
+			const hfs = new Hfs({
+				impl: {
+					deleteAll() {
+						return true;
+					},
+				},
+			});
+
+			const result = await hfs.deleteAll("/path/to/directory");
+			assert.strictEqual(result, true);
+		});
+
+		it("should return false when the impl method returns false", async () => {
+			const hfs = new Hfs({
+				impl: {
+					deleteAll() {
+						return false;
+					},
+				},
+			});
+
+			const result = await hfs.deleteAll("/path/to/directory");
+			assert.strictEqual(result, false);
 		});
 	});
 

--- a/packages/deno/src/deno-hfs.js
+++ b/packages/deno/src/deno-hfs.js
@@ -194,28 +194,47 @@ export class DenoHfsImpl {
 	 * Deletes a file or empty directory.
 	 * @param {string|URL} filePath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	delete(filePath) {
-		return this.#deno.remove(filePath);
+		return this.#deno
+			.remove(filePath)
+			.then(() => true)
+			.catch(error => {
+				if (error.code === "ENOENT") {
+					return false;
+				}
+
+				throw error;
+			});
 	}
 
 	/**
 	 * Deletes a file or directory recursively.
 	 * @param {string|URL} filePath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 * @throws {Error} If the file or directory is not found.
 	 */
 	deleteAll(filePath) {
-		return this.#deno.remove(filePath, { recursive: true });
+		return this.#deno
+			.remove(filePath, { recursive: true })
+			.then(() => true)
+			.catch(error => {
+				if (error.code === "ENOENT") {
+					return false;
+				}
+
+				throw error;
+			});
 	}
 
 	/**

--- a/packages/memory/src/memory-hfs.js
+++ b/packages/memory/src/memory-hfs.js
@@ -152,17 +152,17 @@ export class MemoryHfsImpl {
 	 * Deletes a file or empty directory.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	async delete(fileOrDirPath) {
 		const entry = this.#volume.stat(fileOrDirPath);
 
 		if (!entry) {
-			throw new NotFoundError(`delete '${fileOrDirPath}'`);
+			return false;
 		}
 
 		// if the entry is directory, check to see if its empty with readDir
@@ -175,26 +175,28 @@ export class MemoryHfsImpl {
 		}
 
 		this.#volume.rm(fileOrDirPath);
+		return true;
 	}
 
 	/**
 	 * Deletes a file or directory recursively.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	async deleteAll(fileOrDirPath) {
 		const entry = this.#volume.stat(fileOrDirPath);
 
 		if (!entry) {
-			throw new NotFoundError(`deleteAll '${fileOrDirPath}'`);
+			return false;
 		}
 
 		this.#volume.rm(fileOrDirPath);
+		return true;
 	}
 
 	/**

--- a/packages/node/src/node-hfs.js
+++ b/packages/node/src/node-hfs.js
@@ -246,34 +246,50 @@ export class NodeHfsImpl {
 	 * Deletes a file or empty directory.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	delete(fileOrDirPath) {
-		return this.#fsp.rm(fileOrDirPath).catch(error => {
-			if (error.code === "ERR_FS_EISDIR") {
-				return this.#fsp.rmdir(fileOrDirPath);
-			}
+		return this.#fsp
+			.rm(fileOrDirPath)
+			.then(() => true)
+			.catch(error => {
+				if (error.code === "ERR_FS_EISDIR") {
+					return this.#fsp.rmdir(fileOrDirPath).then(() => true);
+				}
 
-			throw error;
-		});
+				if (error.code === "ENOENT") {
+					return false;
+				}
+
+				throw error;
+			});
 	}
 
 	/**
 	 * Deletes a file or directory recursively.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	deleteAll(fileOrDirPath) {
-		return this.#fsp.rm(fileOrDirPath, { recursive: true });
+		return this.#fsp
+			.rm(fileOrDirPath, { recursive: true })
+			.then(() => true)
+			.catch(error => {
+				if (error.code === "ENOENT") {
+					return false;
+				}
+
+				throw error;
+			});
 	}
 
 	/**

--- a/packages/test/src/hfs-impl-tester.js
+++ b/packages/test/src/hfs-impl-tester.js
@@ -587,55 +587,57 @@ export class HfsImplTester {
 
 					it("should delete a file", async () => {
 						const filePath = dirPath + "/subdir/subsubdir/test.txt";
-						await impl.delete(filePath);
+						const result = await impl.delete(filePath);
 
 						assert.strictEqual(await impl.isFile(filePath), false);
+						assert.strictEqual(result, true);
 					});
 
 					it("should delete a file at the file URL", async () => {
 						const filePath = dirPath + "/subdir/subsubdir/test.txt";
 						const fileUrl = filePathToUrl(filePath);
-						await impl.delete(fileUrl);
+						const result = await impl.delete(fileUrl);
 
 						assert.strictEqual(await impl.isFile(filePath), false);
+						assert.strictEqual(result, true);
 					});
 
 					it("should delete an empty directory", async () => {
 						const emptySubdirPath = dirPath + "/empty-subdir";
-						await impl.delete(emptySubdirPath);
+						const result = await impl.delete(emptySubdirPath);
 
 						assert.strictEqual(
 							await impl.isDirectory(emptySubdirPath),
 							false,
 						);
+						assert.strictEqual(result, true);
 					});
 
 					it("should delete an empty directory at the file URL", async () => {
 						const emptySubdirPath = dirPath + "/empty-subdir";
 						const emptySubdirUrl = filePathToUrl(emptySubdirPath);
-						await impl.delete(emptySubdirUrl);
+						const result = await impl.delete(emptySubdirUrl);
 
 						assert.strictEqual(
 							await impl.isDirectory(emptySubdirPath),
 							false,
 						);
+						assert.strictEqual(result, true);
 					});
 
-					it("should reject a promise when the file doesn't exist", async () => {
+					it("should return false when the file doesn't exist", async () => {
 						const filePath = dirPath + "/nonexistent.txt";
-						await assert.rejects(
-							() => impl.delete(filePath),
-							/ENOENT/,
-						);
+						const result = await impl.delete(filePath);
+
+						assert.strictEqual(result, false);
 					});
 
-					it("should reject a promise when the file doesn't exist at the file URL", async () => {
+					it("should return false when the file doesn't exist at the file URL", async () => {
 						const filePath = dirPath + "/nonexistent.txt";
 						const fileUrl = filePathToUrl(filePath);
-						await assert.rejects(
-							() => impl.delete(fileUrl),
-							/ENOENT/,
-						);
+						const result = await impl.delete(fileUrl);
+
+						assert.strictEqual(result, false);
 					});
 
 					it("should reject a promise when path is a nonempty directory", async () => {
@@ -677,78 +679,82 @@ export class HfsImplTester {
 
 				it("should delete a file", async () => {
 					const filePath = dirPath + "/subdir/subsubdir/test.txt";
-					await impl.deleteAll(filePath);
+					const result = await impl.deleteAll(filePath);
 
 					assert.strictEqual(await impl.isFile(filePath), false);
+					assert.strictEqual(result, true);
 				});
 
 				it("should delete a file at the file URL", async () => {
 					const filePath = dirPath + "/subdir/subsubdir/test.txt";
 					const fileUrl = filePathToUrl(filePath);
-					await impl.deleteAll(fileUrl);
+					const result = await impl.deleteAll(fileUrl);
 
 					assert.strictEqual(await impl.isFile(filePath), false);
+					assert.strictEqual(result, true);
 				});
 
 				it("should delete a directory", async () => {
 					const subsubdirPath = dirPath + "/subdir/subsubdir";
-					await impl.deleteAll(subsubdirPath);
+					const result = await impl.deleteAll(subsubdirPath);
 
 					assert.strictEqual(
 						await impl.isDirectory(subsubdirPath),
 						false,
 					);
+					assert.strictEqual(result, true);
 				});
 
 				it("should delete a directory at the file URL", async () => {
 					const subsubdirPath = dirPath + "/subdir/subsubdir";
 					const subsubdirUrl = filePathToUrl(subsubdirPath);
-					await impl.deleteAll(subsubdirUrl);
+					const result = await impl.deleteAll(subsubdirUrl);
 
 					assert.strictEqual(
 						await impl.isDirectory(subsubdirPath),
 						false,
 					);
+					assert.strictEqual(result, true);
 				});
 
 				it("should delete a directory recursively", async () => {
 					const subdirPath = dirPath + "/subdir";
-					await impl.deleteAll(subdirPath);
+					const result = await impl.deleteAll(subdirPath);
 
 					assert.strictEqual(
 						await impl.isDirectory(subdirPath),
 						false,
 					);
+					assert.strictEqual(result, true);
 				});
 
 				it("should delete a directory recursively at the file URL", async () => {
 					const subdirPath = dirPath + "/subdir";
 					const subdirUrl = filePathToUrl(subdirPath);
-					await impl.deleteAll(subdirUrl);
+					const result = await impl.deleteAll(subdirUrl);
 
 					assert.strictEqual(
 						await impl.isDirectory(subdirPath),
 						false,
 					);
+					assert.strictEqual(result, true);
 				});
 
-				it("should reject a promise when the file doesn't exist", async () => {
+				it("should return false when the file doesn't exist", async () => {
 					const filePath = dirPath + "/nonexistent.txt";
 					assert.strictEqual(await impl.isFile(filePath), false);
-					await assert.rejects(
-						() => impl.deleteAll(filePath),
-						/ENOENT/,
-					);
+
+					const result = await impl.deleteAll(filePath);
+					assert.strictEqual(result, false);
 				});
 
-				it("should reject a promise when the file doesn't exist at the file URL", async () => {
+				it("should return false when the file doesn't exist at the file URL", async () => {
 					const filePath = dirPath + "/nonexistent.txt";
 					const fileUrl = filePathToUrl(filePath);
 					assert.strictEqual(await impl.isFile(filePath), false);
-					await assert.rejects(
-						() => impl.deleteAll(fileUrl),
-						/ENOENT/,
-					);
+
+					const result = await impl.deleteAll(fileUrl);
+					assert.strictEqual(result, false);
 				});
 			});
 

--- a/packages/types/src/hfs-types.ts
+++ b/packages/types/src/hfs-types.ts
@@ -61,18 +61,20 @@ export interface HfsImpl {
 	/**
 	 * Deletes the given file or empty directory.
 	 * @param fileOrDirPath The file or directory to delete.
-	 * @returns A promise that resolves when the file or directory is deleted.
+	 * @returns A promise that resolves when the file or directory is deleted,
+	 * 	true if the file or directory was deleted, false if it did not exist.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
-	delete?(fileOrDirPath: string|URL): Promise<void>;
+	delete?(fileOrDirPath: string|URL): Promise<boolean>;
 
 	/**
 	 * Deletes the given file or directory recursively.
 	 * @param fileOrDirPath The file or directory to delete.
-	 * @returns A promise that resolves when the file or directory is deleted.
+	 * @returns A promise that resolves when the file or directory is deleted,
+	 * 	true if the file or directory was deleted, false if it did not exist.
 	 * @throws {Error} If the file or directory cannot be deleted.
 	 */
-	deleteAll?(fileOrDirPath: string|URL): Promise<void>;
+	deleteAll?(fileOrDirPath: string|URL): Promise<boolean>;
 
 	/**
 	 * Returns a list of directory entries for the given path.

--- a/packages/web/src/web-hfs.js
+++ b/packages/web/src/web-hfs.js
@@ -283,11 +283,11 @@ export class WebHfsImpl {
 	 * Deletes a file or empty directory.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	async delete(fileOrDirPath) {
 		const handle = await findPath(this.#root, fileOrDirPath);
@@ -299,7 +299,7 @@ export class WebHfsImpl {
 			) ?? this.#root;
 
 		if (!handle) {
-			throw new NotFoundError(`delete '${fileOrDirPath}'`);
+			return false;
 		}
 
 		// nonempty directories must not be deleted
@@ -313,23 +313,24 @@ export class WebHfsImpl {
 		}
 
 		parentHandle.removeEntry(handle.name);
+		return true;
 	}
 
 	/**
 	 * Deletes a file or directory recursively.
 	 * @param {string|URL} fileOrDirPath The path to the file or directory to
 	 *   delete.
-	 * @returns {Promise<void>} A promise that resolves when the file or
-	 *   directory is deleted.
+	 * @returns {Promise<boolean>} A promise that resolves when the file or
+	 *   directory is deleted, true if the file or directory is deleted, false
+	 *   if the file or directory does not exist.
 	 * @throws {TypeError} If the file or directory path is not a string.
 	 * @throws {Error} If the file or directory cannot be deleted.
-	 * @throws {Error} If the file or directory is not found.
 	 */
 	async deleteAll(fileOrDirPath) {
 		const handle = await findPath(this.#root, fileOrDirPath);
 
 		if (!handle) {
-			throw new NotFoundError(`deleteAll '${fileOrDirPath}'`);
+			return false;
 		}
 
 		/*
@@ -344,7 +345,7 @@ export class WebHfsImpl {
 		if (handle.remove) {
 			// @ts-ignore -- only supported by Chrome right now
 			await handle.remove({ recursive: true });
-			return;
+			return true;
 		}
 
 		const parentHandle =
@@ -358,6 +359,7 @@ export class WebHfsImpl {
 			throw new NotFoundError(`deleteAll '${fileOrDirPath}'`);
 		}
 		parentHandle.removeEntry(handle.name, { recursive: true });
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Make `delete()` and `deleteAll()` not throw on ENOENT errors. Instead, they should return `false` and otherwise return `true`.

## What changes did you make? (Give an overview)

- Updated `HfsImpl` interface
- Updated `Hfs` to return values from `delete()` and `deleteAll()`
- Updated `delete()` and `deleteAll()` on all runtime impls
- Updated `HfsImplTester` to verify the new behavior
- Documented how the API now works


<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
