### PR TITLE
feat: Add ID-based methods to MemoryHfsVolume + tests

### DIFF
--- a/packages/memory/src/memory-hfs-volume.js
+++ b/packages/memory/src/memory-hfs-volume.js
@@ -15,6 +15,12 @@ import {
 } from "@humanfs/core";
 
 //-----------------------------------------------------------------------------
+// Types
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("@humanfs/types").HfsDirectoryEntry} HfsDirectoryEntry */
+
+//-----------------------------------------------------------------------------
 // Data
 //-----------------------------------------------------------------------------
 
@@ -53,12 +59,12 @@ function findPath(root, fileOrDirPath) {
 	let object = root;
 	let key = parts.shift();
 
-	while (object.get(key)) {
+	while (object.find(key)) {
 		if (parts.length === 0) {
-			return object.get(key);
+			return object.find(key);
 		}
 
-		object = object.get(key);
+		object = /** @type {MemoryHfsDirectory} */ (object.find(key));
 		key = parts.shift();
 	}
 
@@ -69,11 +75,11 @@ function findPath(root, fileOrDirPath) {
  * Writes a file or directory to the volume.
  * @param {MemoryHfsDirectory} volume The volume to search.
  * @param {string|URL} fileOrDirPath The path to the file or directory to find.
- * @param {MemoryHfsDirectory|MemoryHfsFile|undefined} value The value to write.
+ * @param {MemoryHfsDirectory|MemoryHfsFile|undefined} entry The value to write.
  * @returns {Array<MemoryHfsDirectory|MemoryHfsFile>} The files and directories created,
  *    including `value`, or undefined if the directory already exists.
  */
-function writePath(volume, fileOrDirPath, value) {
+function writePath(volume, fileOrDirPath, entry) {
 	const path = Path.from(fileOrDirPath);
 	const name = path.pop();
 	let directory = volume;
@@ -81,28 +87,31 @@ function writePath(volume, fileOrDirPath, value) {
 
 	// create any missing directories
 	for (const step of path) {
-		let entry = directory.get(step);
+		let entry = directory.find(step);
 
 		if (!entry) {
-			entry = new MemoryHfsDirectory();
-			directory.set(step, entry);
+			entry = new MemoryHfsDirectory({
+				name: step,
+			});
+			directory.add(entry);
 			created.push(entry);
 		}
 
-		directory = entry;
+		directory = /** @type {MemoryHfsDirectory} */ (entry);
 	}
 
 	// we don't want to overwrite an existing directory
 	if (
 		directory &&
-		directory.get("name")?.kind === "directory" &&
-		value.kind === "directory"
+		directory.find(name)?.kind === "directory" &&
+		entry.kind === "directory"
 	) {
-		return;
+		return [];
 	}
 
-	directory.set(name, value);
-	created.push(value);
+	entry.name = name;
+	directory.add(entry);
+	created.push(entry);
 
 	return created;
 }
@@ -142,13 +151,22 @@ export class MemoryHfsFile {
 	kind = "file";
 
 	/**
+	 * The name of the file.
+	 * @type {string}
+	 */
+	name;
+
+	/**
 	 * Creates a new instance.
-	 * @param {ArrayBuffer} contents The contents of the file.
+	 * @param {object} options The options for the file.
+	 * @param {string} [options.name] The name of the file.
+	 * @param {ArrayBuffer} options.contents The contents of the file.
 	 * @throws {TypeError} If the contents are not an ArrayBuffer.
 	 */
-	constructor(contents) {
+	constructor({ name, contents }) {
 		assertArrayBuffer(contents);
 		this.#contents = contents;
+		this.name = name;
 	}
 
 	/**
@@ -202,7 +220,10 @@ export class MemoryHfsFile {
 	 * @returns {MemoryHfsFile} The new file.
 	 */
 	clone() {
-		return new MemoryHfsFile(this.#contents.slice(0));
+		return new MemoryHfsFile({
+			name: this.name,
+			contents: this.#contents.slice(0),
+		});
 	}
 }
 
@@ -210,7 +231,7 @@ export class MemoryHfsFile {
  * A class representing a directory in memory.
  * It extends Map to provide the functionality of a directory.
  */
-export class MemoryHfsDirectory extends Map {
+export class MemoryHfsDirectory {
 	/**
 	 * The unique identifier for the directory.
 	 * @type {string}
@@ -219,10 +240,17 @@ export class MemoryHfsDirectory extends Map {
 	#id = `dir-${objectId++}`;
 
 	/**
-	 * A map of names to objects.
-	 * @type {WeakMap<MemoryHfsFile|MemoryHfsDirectory, string>}
+	 * The entries in the directory.
+	 * @type {Array<MemoryHfsFile|MemoryHfsDirectory>}
+	 * @readonly
 	 */
-	#names = new WeakMap();
+	#entries;
+
+	/**
+	 * The name of the directory.
+	 * @type {string}
+	 */
+	name;
 
 	/**
 	 * The last modified date of the directory.
@@ -236,6 +264,17 @@ export class MemoryHfsDirectory extends Map {
 	 * @readonly
 	 */
 	kind = "directory";
+
+	/**
+	 * Creates a new instance.
+	 * @param {Object} [options] The options for the directory.
+	 * @param {string} [options.name] The name of the directory.
+	 * @param {Array<MemoryHfsFile|MemoryHfsDirectory>} [options.entries] The entries in the directory.
+	 */
+	constructor({ name, entries = [] } = {}) {
+		this.name = name;
+		this.#entries = entries;
+	}
 
 	/**
 	 * The unique identifier for the file.
@@ -256,58 +295,59 @@ export class MemoryHfsDirectory extends Map {
 	}
 
 	/**
-	 * Sets a value in the directory.
-	 * @param {string} key The key to set.
+	 * Finds an entry with the given name in the directory.
+	 * @param {string} name The name of the entry to find.
+	 * @returns {MemoryHfsFile|MemoryHfsDirectory|undefined} The entry found or undefined if not found.
+	 */
+	find(name) {
+		return this.#entries.find(entry => entry.name === name);
+	}
+
+	/**
+	 * Adds an entry in the directory.
 	 * @param {MemoryHfsFile|MemoryHfsDirectory} entry The value to set.
 	 * @returns {this} The instance for chaining.
 	 */
-	set(key, entry) {
-		const existing = this.get(key);
+	add(entry) {
+		const existing = this.find(entry.name);
 
 		// if there's already an entry in this name then delete it from the tree
 		if (existing) {
 			parents.delete(existing);
+
+			const index = this.#entries.indexOf(existing);
+			this.#entries.splice(index, 1);
 		}
 
+		this.#entries.push(entry);
 		entry.lastModified = new Date();
 		parents.set(entry, this);
 
-		// save the name
-		this.#names.set(entry, key);
-
-		return super.set(key, entry);
+		return this;
 	}
 
 	/**
-	 * Deletes a value from the directory.
-	 * @param {string} key The key to delete.
+	 * Deletes an entry from the directory.
+	 * @param {string} name The name of the entry to delete.
 	 * @returns {boolean} True if the key was deleted, false if not.
 	 */
-	delete(key) {
+	delete(name) {
 		this.lastModified = new Date();
 
-		if (this.has(key)) {
-			const entry = this.get(key);
+		const entry = this.find(name);
 
+		if (entry) {
 			if (entry.kind === "directory") {
 				parents.delete(entry);
 			}
 
-			this.#names.delete(entry);
+			const index = this.#entries.indexOf(entry);
+			this.#entries.splice(index, 1);
 
-			return super.delete(key);
+			return true;
 		}
 
 		return false;
-	}
-
-	/**
-	 * Retrieves the name of an entry.
-	 * @param {MemoryHfsFile|MemoryHfsDirectory} entry The entry to retrieve the name of.
-	 * @returns {string|undefined} The name of the entry or undefined if not found.
-	 */
-	nameOf(entry) {
-		return this.#names.get(entry);
 	}
 
 	/**
@@ -315,12 +355,20 @@ export class MemoryHfsDirectory extends Map {
 	 * @returns {MemoryHfsDirectory} The new directory.
 	 */
 	clone() {
-		return new MemoryHfsDirectory(
-			Array.from(this.entries()).map(([key, value]) => [
-				key,
-				value.clone(),
-			]),
-		);
+		return new MemoryHfsDirectory({
+			name: this.name,
+			entries: this.#entries.map(entry => entry.clone()),
+		});
+	}
+
+	/**
+	 * Returns an iterator over the entries in the directory.
+	 * @returns {IterableIterator<[string, MemoryHfsFile|MemoryHfsDirectory]>} The iterator.
+	 */
+	*entries() {
+		for (const entry of this.#entries) {
+			yield [entry.name, entry];
+		}
 	}
 }
 
@@ -342,7 +390,7 @@ export class MemoryHfsVolume {
 	 * The root directory of the volume.
 	 * @type {MemoryHfsDirectory}
 	 */
-	#root = new MemoryHfsDirectory();
+	#root = new MemoryHfsDirectory({ name: "." });
 
 	//-----------------------------------------------------------------------------
 	// ID-Based Methods
@@ -354,7 +402,7 @@ export class MemoryHfsVolume {
 	 * @returns {MemoryHfsFile|MemoryHfsDirectory|undefined} The object or undefined if not found.
 	 * @throws {TypeError} If the ID is not a string.
 	 */
-	getObject(id) {
+	#getObject(id) {
 		if (typeof id !== "string") {
 			throw new TypeError("ID must be a string.");
 		}
@@ -368,8 +416,19 @@ export class MemoryHfsVolume {
 	 * @returns {MemoryHfsFile|MemoryHfsDirectory|undefined} The object or undefined if not found.
 	 * @throws {TypeError} If the path is not a string or URL.
 	 */
-	getObjectFromPath(path) {
+	#getObjectFromPath(path) {
 		return findPath(this.#root, Path.from(path));
+	}
+
+	/**
+	 * Retrieves the ID of an object by its path.
+	 * @param {string|URL} path The path to the object to retrieve.
+	 * @returns {string|undefined} The ID of the object or undefined if not found.
+	 * @throws {TypeError} If the path is not a string or URL.
+	 */
+	getObjectIdFromPath(path) {
+		const object = findPath(this.#root, Path.from(path));
+		return object ? object.id : undefined;
 	}
 
 	/**
@@ -386,11 +445,142 @@ export class MemoryHfsVolume {
 		}
 
 		// remove the object from the tree
-		const name = object.parent.nameOf(object);
-		object.parent.delete(name);
+		object.parent.delete(object.name);
 
 		// remove the object from the map
 		this.#objects.delete(id);
+	}
+
+	/**
+	 * Creates a file.
+	 * @param {string} name The name of the file.
+	 * @param {string} parentId The ID of the parent directory.
+	 * @param {ArrayBuffer} contents The contents of the file.
+	 * @returns {string} The ID of the file.
+	 * @throws {DirectoryError} If the parent ID is not a directory.
+	 * @throws {NotFoundError} If the parent ID is not found.
+	 * @throws {TypeError} If the contents are not an ArrayBuffer.
+	 */
+	createFileObject(name, parentId, contents) {
+		const parent = this.#objects.get(parentId);
+
+		if (!parent) {
+			throw new NotFoundError(`createObject ${parentId}`);
+		}
+
+		if (parent.kind !== "directory") {
+			throw new DirectoryError(`createObject ${parentId}`);
+		}
+
+		const directory = /** @type {MemoryHfsDirectory} */ (parent);
+		const file = new MemoryHfsFile({ name, contents });
+
+		directory.add(file);
+		this.#objects.set(file.id, file);
+
+		return file.id;
+	}
+
+	/**
+	 * Creates a directory.
+	 * @param {string} name The name of the directory.
+	 * @param {string} parentId The ID of the parent directory.
+	 * @returns {string} The ID of the directory.
+	 * @throws {DirectoryError} If the parent ID is not a directory.
+	 * @throws {NotFoundError} If the parent ID is not found.
+	 */
+	createDirectoryObject(name, parentId) {
+		const parent = this.#objects.get(parentId);
+
+		if (!parent) {
+			throw new NotFoundError(`createObject ${parentId}`);
+		}
+
+		if (parent.kind !== "directory") {
+			throw new DirectoryError(`createObject ${parentId}`);
+		}
+
+		const directory = /** @type {MemoryHfsDirectory} */ (parent);
+		const newDirectory = new MemoryHfsDirectory({ name });
+
+		directory.add(newDirectory);
+		this.#objects.set(newDirectory.id, newDirectory);
+
+		return newDirectory.id;
+	}
+
+	/**
+	 * Reads the contents of a file.
+	 * @param {string} id The ID of the file to read.
+	 * @returns {ArrayBuffer|undefined} The contents of the file or
+	 * undefined if not found.
+	 * @throws {NotFoundError} If the file is not found.
+	 * @throws {DirectoryError} If the ID is not a file.
+	 */
+	readFileObject(id) {
+		const object = this.#objects.get(id);
+
+		if (!object) {
+			return undefined;
+		}
+
+		if (object.kind !== "file") {
+			throw new DirectoryError(`readObject ${id}`);
+		}
+
+		return /** @type {MemoryHfsFile} */ (object).contents;
+	}
+
+	/**
+	 * Writes the contents of a file.
+	 * @param {string} id The ID of the file to write.
+	 * @param {ArrayBuffer} contents The contents to write.
+	 * @returns {void}
+	 * @throws {NotFoundError} If the file is not found.
+	 * @throws {DirectoryError} If the ID is not a file.
+	 * @throws {TypeError} If the contents are not an ArrayBuffer.
+	 */
+	writeFileObject(id, contents) {
+		const object = this.#objects.get(id);
+
+		if (!object) {
+			throw new NotFoundError(`writeObject ${id}`);
+		}
+
+		if (object.kind !== "file") {
+			throw new DirectoryError(`writeObject ${id}`);
+		}
+
+		const file = /** @type {MemoryHfsFile} */ (object);
+		file.contents = contents;
+	}
+
+	/**
+	 * Reads the contents of a directory.
+	 * @param {string} id The ID of the directory to read.
+	 * @returns {Array<HfsDirectoryEntry>} The names of the files and directories in the directory.
+	 * @throws {NotFoundError} If the directory is not found.
+	 * @throws {DirectoryError} If the ID is not a directory.
+	 */
+	readDirectoryObject(id) {
+		const object = this.#objects.get(id);
+
+		if (!object) {
+			throw new NotFoundError(`readObject ${id}`);
+		}
+
+		if (object.kind !== "directory") {
+			throw new DirectoryError(`readObject ${id}`);
+		}
+
+		const directory = /** @type {MemoryHfsDirectory} */ (object);
+
+		return Array.from(directory.entries()).map(([name, object]) => ({
+			isFile: object.kind === "file",
+			isDirectory: object.kind === "directory",
+			isSymlink: false,
+			name: name,
+		}));
 	}
 
 	//-----------------------------------------------------------------------------
@@ -426,7 +616,7 @@ export class MemoryHfsVolume {
 		for (const entry of writePath(
 			this.#root,
 			filePath,
-			new MemoryHfsFile(contents),
+			new MemoryHfsFile({ contents }),
 		)) {
 			this.#objects.set(entry.id, entry);
 		}
@@ -460,7 +650,10 @@ export class MemoryHfsVolume {
 		const destDir = /** @type {MemoryHfsDirectory} */ (
 			findPath(this.#root, destPath)
 		);
-		destDir.set(name, object.clone());
+
+		const newObject = object.clone();
+		newObject.name = name;
+		destDir.add(newObject);
 	}
 
 	/**
@@ -492,7 +685,9 @@ export class MemoryHfsVolume {
 		const destDir = /** @type {MemoryHfsDirectory} */ (
 			findPath(this.#root, destPath)
 		);
-		destDir.set(name, object.clone());
+		const newObject = object.clone();
+		newObject.name = name;
+		destDir.add(newObject);
 
 		// remove the original
 		object.parent.delete(srcPath.name);
@@ -580,7 +775,7 @@ export class MemoryHfsVolume {
 			findPath(this.#root, path)
 		);
 
-		if (!object || !object.has(name)) {
+		if (!object || !object.find(name)) {
 			throw new NotFoundError(`rm ${fileOrDirPath}`);
 		}
 

--- a/packages/memory/tests/memory-hfs-volume.test.js
+++ b/packages/memory/tests/memory-hfs-volume.test.js
@@ -1,0 +1,334 @@
+/**
+ * @fileoverview Tests for the MemoryHfsVolume class.
+ * @author Nicholas C. Zakas
+ */
+
+/*global describe, it, TextEncoder, beforeEach */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import {
+	MemoryHfsDirectory,
+	MemoryHfsFile,
+	MemoryHfsVolume,
+} from "../src/memory-hfs-volume.js";
+import assert from "node:assert";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+function toBuffer(str) {
+	return new TextEncoder().encode(str).buffer;
+}
+
+const HELLO_WORLD = toBuffer("Hello, world!");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("MemoryHfsVolume", () => {
+	let volume;
+
+	beforeEach(() => {
+		volume = new MemoryHfsVolume();
+	});
+
+	describe("writeFile()", () => {
+		it("should throw an error when writeFile() is called with a string as contents", () => {
+			assert.throws(
+				() => volume.writeFile("file.txt", "Hello, world!"),
+				/Value must be an ArrayBuffer/,
+			);
+		});
+
+		it("should throw an error when writeFile() is called with a number as contents", () => {
+			assert.throws(
+				() => volume.writeFile("file.txt", 42),
+				/Value must be an ArrayBuffer/,
+			);
+		});
+
+		it("should write a file to the volume", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+
+			const file = volume.readFile("file.txt");
+			assert.strictEqual(file, HELLO_WORLD);
+		});
+
+		it("should write a file to the volume with a parent directory", () => {
+			volume.writeFile("dir/file.txt", HELLO_WORLD);
+
+			const file = volume.readFile("dir/file.txt");
+			assert.strictEqual(file, HELLO_WORLD);
+		});
+
+		it("should write a file to the volume with a parent directory that already exists", () => {
+			volume.mkdirp("dir");
+			volume.writeFile("dir/file.txt", HELLO_WORLD);
+
+			const file = volume.readFile("dir/file.txt");
+			assert.strictEqual(file, HELLO_WORLD);
+		});
+	});
+
+	describe("readFile()", () => {
+		it("should return undefined when reading a file that doesn't exist", () => {
+			const file = volume.readFile("file.txt");
+			assert.strictEqual(file, undefined);
+		});
+
+		it("should throw an error when the path is a directory", () => {
+			volume.mkdirp("dir");
+			assert.throws(
+				() => volume.readFile("dir"),
+				/Illegal operation on a directory/,
+			);
+		});
+
+		it("should read a file from the volume", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+
+			const file = volume.readFile("file.txt");
+			assert.strictEqual(file, HELLO_WORLD);
+		});
+
+		it("should read a file from the volume with a parent directory", () => {
+			volume.writeFile("dir/file.txt", HELLO_WORLD);
+
+			const file = volume.readFile("dir/file.txt");
+			assert.strictEqual(file, HELLO_WORLD);
+		});
+	});
+
+	describe("mkdirp()", () => {
+		it("should create a directory", () => {
+			volume.mkdirp("dir");
+			const dir = volume.readdir("dir");
+			assert.deepStrictEqual(dir, []);
+		});
+
+		it("should create a directory with a parent directory", () => {
+			volume.mkdirp("dir/subdir");
+			const dir = volume.readdir("dir/subdir");
+			assert.deepStrictEqual(dir, []);
+		});
+
+		it("should create a directory with a parent directory that already exists", () => {
+			volume.mkdirp("dir");
+			volume.mkdirp("dir/subdir");
+			const dir = volume.readdir("dir/subdir");
+			assert.deepStrictEqual(dir, []);
+		});
+	});
+
+	describe("readdir()", () => {
+		it("should throw an error when the path doesn't exist", () => {
+			assert.throws(() => volume.readdir("dir"), /ENOENT/);
+		});
+
+		it("should throw an error when the path is a file", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			assert.throws(() => volume.readdir("file.txt"), /EPERM/);
+		});
+
+		it("should return an empty array when reading an empty directory", () => {
+			volume.mkdirp("dir");
+			const dir = volume.readdir("dir");
+			assert.deepStrictEqual(dir, []);
+		});
+
+		it("should return an array of files when reading a directory with files", () => {
+			volume.writeFile("dir/file1.txt", HELLO_WORLD);
+			volume.writeFile("dir/file2.txt", HELLO_WORLD);
+
+			const dir = volume.readdir("dir");
+			assert.deepStrictEqual(dir, [
+				{
+					name: "file1.txt",
+					isDirectory: false,
+					isFile: true,
+					isSymlink: false,
+				},
+				{
+					name: "file2.txt",
+					isDirectory: false,
+					isFile: true,
+					isSymlink: false,
+				},
+			]);
+		});
+	});
+
+	describe("mv()", () => {
+		it("should throw an error when the source path doesn't exist", () => {
+			assert.throws(
+				() => volume.mv("file.txt", "dir/file.txt"),
+				/ENOENT/,
+			);
+		});
+
+		it("should throw an error when the destination path is a directory", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			volume.mkdirp("dir");
+			assert.throws(() => volume.mv("file.txt", "dir"), /EISDIR/);
+		});
+
+		it("should move a file to a new location", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			volume.mkdirp("dir");
+			volume.mv("file.txt", "dir/file.txt");
+			const file = volume.readFile("dir/file.txt");
+			assert.deepEqual(file, HELLO_WORLD);
+		});
+	});
+
+	describe("rm()", () => {
+		it("should throw an error when the path doesn't exist", () => {
+			assert.throws(() => volume.rm("file.txt"), /ENOENT/);
+		});
+
+		it("should remove a file", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			volume.rm("file.txt");
+			assert.strictEqual(volume.readFile("file.txt"), undefined);
+		});
+
+		it("should remove a directory", () => {
+			volume.mkdirp("dir");
+			volume.rm("dir");
+
+			assert.strictEqual(volume.stat("dir"), undefined);
+		});
+	});
+
+	describe("stat()", () => {
+		it("should return undefined when the path doesn't exist", () => {
+			assert.strictEqual(volume.stat("file.txt"), undefined);
+		});
+
+		it("should return information about a file", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			const stats = volume.stat("file.txt");
+
+			assert.strictEqual(stats.kind, "file");
+			assert.strictEqual(stats.size, HELLO_WORLD.byteLength);
+			assert.strictEqual(stats.mtime instanceof Date, true);
+		});
+
+		it("should return information about a directory", () => {
+			volume.mkdirp("dir");
+			const stats = volume.stat("dir");
+
+			assert.strictEqual(stats.kind, "directory");
+			assert.strictEqual(stats.size, 0);
+			assert.strictEqual(stats.mtime instanceof Date, true);
+		});
+	});
+
+	describe("cp()", () => {
+		it("should throw an error when the source path doesn't exist", () => {
+			assert.throws(
+				() => volume.cp("file.txt", "dir/file.txt"),
+				/ENOENT/,
+			);
+		});
+
+		it("should throw an error when the destination path is a directory", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			volume.mkdirp("dir");
+			assert.throws(() => volume.cp("file.txt", "dir"), /EISDIR/);
+		});
+
+		it("should copy a file to a new location", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			volume.mkdirp("dir");
+			volume.cp("file.txt", "dir/file.txt");
+			const file = volume.readFile("dir/file.txt");
+			assert.deepEqual(file, HELLO_WORLD);
+		});
+	});
+
+	describe("getObjectFromPath()", () => {
+		it("should return a directory object when passed a directory path", () => {
+			volume.mkdirp("dir");
+			const object = volume.getObjectFromPath("dir");
+			assert.strictEqual(object instanceof MemoryHfsDirectory, true);
+			assert.strictEqual(object.id.startsWith("dir-"), true);
+		});
+
+		it("should return a file object when passed a file path", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			const object = volume.getObjectFromPath("file.txt");
+			assert.strictEqual(object instanceof MemoryHfsFile, true);
+			assert.strictEqual(object.id.startsWith("file-"), true);
+		});
+
+		it("should return undefined when the path doesn't exist", () => {
+			const object = volume.getObjectFromPath("file.txt");
+			assert.strictEqual(object, undefined);
+		});
+	});
+
+	describe("getObject()", () => {
+		it("should return a directory object when passed a directory ID", () => {
+			volume.mkdirp("dir");
+			const objectFromPath = volume.getObjectFromPath("dir");
+			const objectFromId = volume.getObject(objectFromPath.id);
+			assert.strictEqual(objectFromPath, objectFromId);
+			assert.strictEqual(
+				objectFromId instanceof MemoryHfsDirectory,
+				true,
+			);
+		});
+
+		it("should return a file object when passed a file ID", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			const objectFromPath = volume.getObjectFromPath("file.txt");
+			const objectFromId = volume.getObject(objectFromPath.id);
+			assert.strictEqual(objectFromPath, objectFromId);
+			assert.strictEqual(objectFromId instanceof MemoryHfsFile, true);
+		});
+
+		it("should return undefined when the ID doesn't exist", () => {
+			const object = volume.getObject("file-1");
+			assert.strictEqual(object, undefined);
+		});
+	});
+
+	describe("deleteObject()", () => {
+		it("should delete a directory object", () => {
+			volume.mkdirp("dir");
+			const object = volume.getObjectFromPath("dir");
+			volume.deleteObject(object.id);
+
+			const stat = volume.stat("dir");
+			assert.strictEqual(stat, undefined);
+		});
+
+		it("should delete a file object", () => {
+			volume.writeFile("file.txt", HELLO_WORLD);
+			const object = volume.getObjectFromPath("file.txt");
+			volume.deleteObject(object.id);
+
+			const stat = volume.stat("file.txt");
+			assert.strictEqual(stat, undefined);
+		});
+
+		it("should delete a file in a subdirectory", () => {
+			volume.writeFile("dir/file.txt", HELLO_WORLD);
+			const object = volume.getObjectFromPath("dir/file.txt");
+			volume.deleteObject(object.id);
+
+			const stat = volume.stat("dir/file.txt");
+			assert.strictEqual(stat, undefined);
+		});
+
+		it("should throw an error when the ID doesn't exist", () => {
+			assert.throws(() => volume.deleteObject("file-1"), /ENOENT/);
+		});
+	});
+});


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Add ID-based methods to `MemoryHfsVolume` to make it more useful for mocking out API-based file systems.

## What changes did you make? (Give an overview)

- Added new methods to `MemoryHfsVolume`
- Refactored `MemoryHfsDirectory` and `MemoryHfsFile` to make accessing by ID easier
- Added tests

<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?

<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
