### PR TITLE
fix: Ensure walk() doesn't error out on directory ENOENT

### DIFF
--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -540,10 +540,24 @@ export class Hfs {
 			dirPath,
 			{ directoryFilter, entryFilter, parentPath = "", depth = 1 },
 		) {
-			for await (const listEntry of this.#callImplMethodWithoutLog(
-				"list",
-				dirPath,
-			)) {
+			let dirEntries;
+
+			try {
+				dirEntries = await this.#callImplMethodWithoutLog(
+					"list",
+					dirPath,
+				);
+			} catch (error) {
+				// if the directory does not exist then return an empty array
+				if (error.code === "ENOENT") {
+					return;
+				}
+
+				// otherwise, rethrow the error
+				throw error;
+			}
+
+			for await (const listEntry of dirEntries) {
 				const walkEntry = {
 					path: listEntry.name,
 					depth,


### PR DESCRIPTION
<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?

Ensures that `walk()` doesn't error out on ENOENT errors. Due to the asynchronous nature of listing directory entries, it's possible that a directory may have been deleted before `list()` is called on it. 

Other packages that do this:
- `glob` - https://github.com/isaacs/node-glob/blob/main/src/processor.ts#L138
- `fast-glob` - https://github.com/mrmlnc/fast-glob/blob/master/src/providers/filters/error.ts#L18

Refs https://github.com/eslint/eslint/issues/18955

## What changes did you make? (Give an overview)

This pull request includes changes to handle directory listing errors more gracefully in the `Hfs` class and adds corresponding tests to ensure the new behavior is correct. The most important changes include modifying the `walk` method to handle `ENOENT` errors, updating the test suite to include a test for this new behavior, and importing necessary error classes.

Error handling improvements:

* [`packages/core/src/hfs.js`](diffhunk://#diff-882fe13bbcf69fe5014e22a1d28d7529e87f91d4380a1959ff24065449403a7bL543-R560): Modified the `walk` method to catch `ENOENT` errors and return an empty array instead of throwing an error.

Test suite updates:

* [`packages/core/tests/hfs.test.js`](diffhunk://#diff-0bb2864cb7f592db5a3441c7f2c97bc33bffacae70da965ad541a7c1b2c6fa1aR1880-R1913): Added a new test case to verify that the `walk` method silently skips directories when `list()` throws an `ENOENT` error.
* [`packages/core/tests/hfs.test.js`](diffhunk://#diff-0bb2864cb7f592db5a3441c7f2c97bc33bffacae70da965ad541a7c1b2c6fa1aR17): Imported `NotFoundError` from `errors.js` to use in the new test case.