### PR TITLE
fix: update retry dependency in node package to avoid duplication. Fixes #138.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11569,7 +11569,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "devDependencies": {
         "@humanfs/test": "^0.15.0",
@@ -11580,6 +11580,19 @@
       },
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "packages/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "packages/test": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@humanwhocodes/retry": "^0.3.0",
+    "@humanwhocodes/retry": "^0.4.0",
     "@humanfs/core": "^0.19.1"
   }
 }


### PR DESCRIPTION
Fixes #138

<!--
    STOP!!! Before submitting a pull request that changes any source code, please open an issue explaining what you'd like to change first. Code changes are NOT accepted without an open issue.

    If you are only making documentation changes, you are welcome to continue without an issue.
-->

## What is the purpose of this pull request?
This PR fixes issue #138 - it updates the dependency of retry in the node package to ^0.4.0 to reduce duplication caused by the fact that eslint 9 depends on "@humanwhocodes/retry" "^0.4.0" and "@humanfs/node" "^0.16.6" but the latter depends on "@humanwhocodes/retry" "^0.3.0" and not "^0.4.0".

## What changes did you make? (Give an overview)
This changes only the dependencies in package.json for the node pacakge.
<!--
    The following is required for all code-related changes:

    - updated documentation
    - updated tests
-->

## What issue(s) does this PR address?
fixes #138
<!--
    Example:

    fixes #1234
    refs #567
-->

## Is there anything you'd like reviewers to focus on?
