### PR TITLE
feat: add followSymlinks option to walk()

### DIFF
--- a/docs/directory-operations.md
+++ b/docs/directory-operations.md
@@ -140,6 +140,16 @@ for await (const entry of hfs.walk("/path/to/directory", { entryFilter })) {
 
 **Note:** Both `directoryFilter` and `entryFilter` may return a promise.
 
+By default, `hfs.walk()` does not traverse symbolic links that point to directories. To follow them, set the `followSymlinks` option to `true`:
+
+```js
+for await (const entry of hfs.walk("/path/to/directory", { followSymlinks: true })) {
+	console.log(entry.path);
+}
+```
+
+**Note:** `followSymlinks` does not guard against symbolic links that form a cycle, so avoid enabling it on directory trees that may contain circular links.
+
 Each entry in the async iterator implements the [`HfsWalkEntry` interface](../packages/types/src/@humanfs/types.ts).
 
 ## Retrieving Directory Modification Time

--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -523,6 +523,8 @@ export class Hfs {
 	 * 	if a directory's entries should be included in the walk.
 	 * @param {(entry:HfsWalkEntry) => Promise<boolean>|boolean} [options.entryFilter] A filter function to determine if
 	 * 	an entry should be included in the walk.
+	 * @param {boolean} [options.followSymlinks] When `true`, symbolic links that
+	 * 	point to directories are traversed. Defaults to `false`.
 	 * @returns {AsyncIterable<HfsWalkEntry>} A promise that resolves with the
 	 * 	directory entries.
 	 * @throws {TypeError} If the directory path is not a string or URL.
@@ -530,15 +532,29 @@ export class Hfs {
 	 */
 	async *walk(
 		dirPath,
-		{ directoryFilter = () => true, entryFilter = () => true } = {},
+		{
+			directoryFilter = () => true,
+			entryFilter = () => true,
+			followSymlinks = false,
+		} = {},
 	) {
 		assertValidFileOrDirPath(dirPath);
-		this.#log("walk", dirPath, { directoryFilter, entryFilter });
+		this.#log("walk", dirPath, {
+			directoryFilter,
+			entryFilter,
+			followSymlinks,
+		});
 
 		// inner function for recursion without additional logging
 		const walk = async function* (
 			dirPath,
-			{ directoryFilter, entryFilter, parentPath = "", depth = 1 },
+			{
+				directoryFilter,
+				entryFilter,
+				followSymlinks,
+				parentPath = "",
+				depth = 1,
+			},
 		) {
 			let dirEntries;
 
@@ -578,8 +594,34 @@ export class Hfs {
 					yield walkEntry;
 				}
 
-				// if it's a directory then yield the entry and walk the directory
-				if (listEntry.isDirectory) {
+				// make sure there's a trailing slash on the directory path before appending
+				const entryPath =
+					dirPath instanceof URL
+						? new URL(
+								listEntry.name,
+								dirPath.href.endsWith("/")
+									? dirPath.href
+									: `${dirPath.href}/`,
+							)
+						: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
+
+				// real directories are always walked; symlinked directories are
+				// only walked when `followSymlinks` is enabled
+				let isWalkableDirectory = listEntry.isDirectory;
+
+				if (
+					!isWalkableDirectory &&
+					followSymlinks &&
+					listEntry.isSymlink
+				) {
+					isWalkableDirectory = await this.#callImplMethodWithoutLog(
+						"isDirectory",
+						entryPath,
+					);
+				}
+
+				// if it's a directory then walk into it
+				if (isWalkableDirectory) {
 					// if the directory filter returns false, skip the directory
 					let shouldWalkDirectory = directoryFilter(walkEntry);
 					if (shouldWalkDirectory.then) {
@@ -590,20 +632,10 @@ export class Hfs {
 						continue;
 					}
 
-					// make sure there's a trailing slash on the directory path before appending
-					const directoryPath =
-						dirPath instanceof URL
-							? new URL(
-									listEntry.name,
-									dirPath.href.endsWith("/")
-										? dirPath.href
-										: `${dirPath.href}/`,
-								)
-							: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
-
-					yield* walk(directoryPath, {
+					yield* walk(entryPath, {
 						directoryFilter,
 						entryFilter,
+						followSymlinks,
 						parentPath: walkEntry.path,
 						depth: depth + 1,
 					});
@@ -611,7 +643,7 @@ export class Hfs {
 			}
 		}.bind(this);
 
-		yield* walk(dirPath, { directoryFilter, entryFilter });
+		yield* walk(dirPath, { directoryFilter, entryFilter, followSymlinks });
 	}
 
 	/**

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -1626,7 +1626,11 @@ describe("Hfs", () => {
 						methodName: "walk",
 						args: [
 							"/path/to/dir",
-							{ directoryFilter, entryFilter },
+							{
+								directoryFilter,
+								entryFilter,
+								followSymlinks: false,
+							},
 						],
 					},
 				},
@@ -1718,6 +1722,88 @@ describe("Hfs", () => {
 			}
 
 			assert.deepStrictEqual(entries, traversed);
+		});
+
+		describe("followSymlinks", () => {
+			let linkHfs;
+
+			beforeEach(() => {
+				const linkData = {
+					"/root": [
+						{
+							name: "link",
+							isFile: false,
+							isDirectory: false,
+							isSymlink: true,
+						},
+						{
+							name: "file.txt",
+							isFile: true,
+							isDirectory: false,
+							isSymlink: false,
+						},
+					],
+					"/root/link": [
+						{
+							name: "inside.txt",
+							isFile: true,
+							isDirectory: false,
+							isSymlink: false,
+						},
+					],
+				};
+
+				linkHfs = new Hfs({
+					impl: {
+						list(dirPath) {
+							if (dirPath instanceof URL) {
+								dirPath = dirPath.pathname;
+							}
+
+							if (dirPath.endsWith("/")) {
+								dirPath = dirPath.slice(0, -1);
+							}
+
+							return linkData[dirPath] ?? [];
+						},
+
+						// resolves the symlink target the way a real fs would
+						isDirectory(dirPath) {
+							if (dirPath instanceof URL) {
+								dirPath = dirPath.pathname;
+							}
+
+							return dirPath.replace(/\/$/u, "") === "/root/link";
+						},
+					},
+				});
+			});
+
+			it("should not walk symlinked directories by default", async () => {
+				const entries = [];
+
+				for await (const entry of linkHfs.walk("/root")) {
+					entries.push(entry.path);
+				}
+
+				assert.deepStrictEqual(entries, ["link", "file.txt"]);
+			});
+
+			it("should walk symlinked directories when followSymlinks is true", async () => {
+				const entries = [];
+
+				for await (const entry of linkHfs.walk("/root", {
+					followSymlinks: true,
+				})) {
+					entries.push(entry.path);
+				}
+
+				assert.deepStrictEqual(entries, [
+					"link",
+					"link/inside.txt",
+					"file.txt",
+				]);
+			});
 		});
 
 		it("should return the list of files and directories when passed a URL without a trailing slash", async () => {

--- a/packages/node/tests/node-hfs.test.js
+++ b/packages/node/tests/node-hfs.test.js
@@ -9,7 +9,7 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import { NodeHfsImpl } from "../src/node-hfs.js";
+import { NodeHfsImpl, NodeHfs } from "../src/node-hfs.js";
 import assert from "node:assert";
 import fsp from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -335,6 +335,92 @@ describe("NodeHfsImpl Customizations", () => {
 				// the symlink must point to the original target, not contain its data
 				const linkTarget = await fsp.readlink(copiedLink);
 				assert.strictEqual(linkTarget, secret);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true });
+			}
+		});
+	});
+
+	describe("walk()", () => {
+		async function collectPaths(hfs, dirPath, options) {
+			const paths = [];
+
+			for await (const entry of hfs.walk(dirPath, options)) {
+				paths.push(entry.path);
+			}
+
+			return paths;
+		}
+
+		it("should not walk into symlinked directories by default", async () => {
+			const tmpDir = await fsp.mkdtemp(
+				path.join(os.tmpdir(), "humanfs-walk-symlink-"),
+			);
+			try {
+				await fsp.mkdir(path.join(tmpDir, "target"));
+				await fsp.writeFile(
+					path.join(tmpDir, "target/inside.txt"),
+					"hello",
+				);
+
+				try {
+					await fsp.symlink(
+						path.join(tmpDir, "target"),
+						path.join(tmpDir, "link"),
+					);
+				} catch (err) {
+					if (err.code === "EPERM") {
+						return; // symlinks require elevated privileges on this OS; skip
+					}
+					throw err;
+				}
+
+				const paths = await collectPaths(new NodeHfs(), tmpDir);
+
+				assert.ok(
+					paths.includes("target/inside.txt"),
+					"real directory should be walked",
+				);
+				assert.ok(
+					!paths.includes("link/inside.txt"),
+					"symlinked directory should not be walked by default",
+				);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true });
+			}
+		});
+
+		it("should walk into symlinked directories when followSymlinks is true", async () => {
+			const tmpDir = await fsp.mkdtemp(
+				path.join(os.tmpdir(), "humanfs-walk-symlink-"),
+			);
+			try {
+				await fsp.mkdir(path.join(tmpDir, "target"));
+				await fsp.writeFile(
+					path.join(tmpDir, "target/inside.txt"),
+					"hello",
+				);
+
+				try {
+					await fsp.symlink(
+						path.join(tmpDir, "target"),
+						path.join(tmpDir, "link"),
+					);
+				} catch (err) {
+					if (err.code === "EPERM") {
+						return; // symlinks require elevated privileges on this OS; skip
+					}
+					throw err;
+				}
+
+				const paths = await collectPaths(new NodeHfs(), tmpDir, {
+					followSymlinks: true,
+				});
+
+				assert.ok(
+					paths.includes("link/inside.txt"),
+					"symlinked directory should be walked when followSymlinks is true",
+				);
 			} finally {
 				await fsp.rm(tmpDir, { recursive: true });
 			}


### PR DESCRIPTION
## What is the purpose of this pull request?

Add an opt-in `followSymlinks` option to `hfs.walk()` so symbolic links that point to directories can be traversed. This is the enabling change for eslint/eslint#19963, where ESLint stopped discovering files under symlinked directories after adopting humanfs for file discovery.

## What changes did you make? (Give an overview)

- `@humanfs/core`: `walk()` now accepts a `followSymlinks` option (default `false`). When it's enabled, an entry that is a symlink is resolved with the impl's `isDirectory()` and walked if it points to a directory. Default behavior is unchanged.
- Tests: unit tests in `@humanfs/core` using a mock impl (covering both the default and `followSymlinks: true`), plus real-symlink integration tests in `@humanfs/node` (skipped on platforms that need elevated privileges to create symlinks).
- Docs: documented the option in `docs/directory-operations.md`, including a note that it does not guard against cyclic symlinks.

## What issue(s) does this PR address?

refs #162
refs eslint/eslint#19963

## Is there anything you'd like reviewers to focus on?

Mainly the design choice. I went with an opt-in option (default off, no behavior change) rather than following symlinks by default, and it doesn't add cycle protection, so the caller owns that risk. I'm happy to switch to follow-by-default or add cycle handling if you'd prefer.
