### PR TITLE
feat: Add followSymlinks option to walk()

### DIFF
--- a/docs/directory-operations.md
+++ b/docs/directory-operations.md
@@ -79,12 +79,12 @@ for await (const entry of hfs.list("/path/to/directory")) {
 	if (entry.isFile) {
 		processFile(entry.name);
 	} else if (entry.isDirectory) {
-		processDirectory(entry.name)
+		processDirectory(entry.name);
 	}
 }
 ```
 
-Each entry in the async iterator implements the [`HfsDirectoryEntry` interface](../packages/types/src/@humanfs/types.ts).
+Each entry in the async iterator implements the [`HfsDirectoryEntry` interface](../packages/types/src/hfs-types.ts).
 
 ## Reading Directory Entries Recursively
 
@@ -92,17 +92,17 @@ To recursively read all of the entries in a given directory, use the `hfs.walk()
 
 ```js
 for await (const entry of hfs.walk("/path/to/directory")) {
-	console.log(entry.path);	// path from /path/to/directory
+	console.log(entry.path); // path from /path/to/directory
 
 	if (entry.isFile) {
 		processFile(entry.name);
 	} else if (entry.isDirectory) {
-		processDirectory(entry.name)
+		processDirectory(entry.name);
 	}
 }
 ```
 
-Each entry in the async iterator implements the [`HfsWalkEntry` interface](../packages/types/src/@humanfs/types.ts).
+Each entry in the async iterator implements the [`HfsWalkEntry` interface](../packages/types/src/hfs-types.ts).
 
 You can determine whether or not to walk into a subdirectory by providing the `directoryFilter` option. This function receives the entry and returns `true` to indicate that the subdirectory should be walked or `false` to indicate the subdirectory should be skipped:
 
@@ -111,12 +111,12 @@ You can determine whether or not to walk into a subdirectory by providing the `d
 const directoryFilter = entry => entry.name !== "skip-me";
 
 for await (const entry of hfs.walk("/path/to/directory", { directoryFilter })) {
-	console.log(entry.path);	// path from /path/to/directory
+	console.log(entry.path); // path from /path/to/directory
 
 	if (entry.isFile) {
 		processFile(entry.name);
 	} else if (entry.isDirectory) {
-		processDirectory(entry.name)
+		processDirectory(entry.name);
 	}
 }
 ```
@@ -128,19 +128,33 @@ Similarly, you can determine which entries are emitted from the async iterable b
 const entryFilter = entry => entry.isFile;
 
 for await (const entry of hfs.walk("/path/to/directory", { entryFilter })) {
-	console.log(entry.path);	// path from /path/to/directory
+	console.log(entry.path); // path from /path/to/directory
 
 	if (entry.isFile) {
 		processFile(entry.name);
 	} else if (entry.isDirectory) {
-		processDirectory(entry.name)
+		processDirectory(entry.name);
 	}
 }
 ```
 
 **Note:** Both `directoryFilter` and `entryFilter` may return a promise.
 
-Each entry in the async iterator implements the [`HfsWalkEntry` interface](../packages/types/src/@humanfs/types.ts).
+By default, `hfs.walk()` does not walk into symbolic links that point to directories (the link itself is still emitted as an entry with `isSymlink` set to `true`). To walk into symlinked directories, set the `followSymlinks` option to `true`:
+
+```js
+for await (const entry of hfs.walk("/path/to/directory", {
+	followSymlinks: true,
+})) {
+	console.log(entry.path); // path from /path/to/directory
+}
+```
+
+When `followSymlinks` is `true`, each symlink entry is checked to see if it points to a directory. If it does, the entry is passed to `directoryFilter` (the entry still has `isSymlink` set to `true` and `isDirectory` set to `false`) and, if not filtered out, its contents are walked. Symlinks that point to files or that are broken are emitted but never walked into.
+
+**Note:** `followSymlinks` does not protect against circular symbolic links. Walking a directory tree with a symlink that points to one of its own ancestors will not terminate, so only enable this option for directory trees you control.
+
+Each entry in the async iterator implements the [`HfsWalkEntry` interface](../packages/types/src/hfs-types.ts).
 
 ## Retrieving Directory Modification Time
 

--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -521,6 +521,9 @@ export class Hfs {
 	 * 	if a directory's entries should be included in the walk.
 	 * @param {(entry:HfsWalkEntry) => Promise<boolean>|boolean} [options.entryFilter] A filter function to determine if
 	 * 	an entry should be included in the walk.
+	 * @param {boolean} [options.followSymlinks] When `true`, symbolic links that
+	 * 	point to directories are walked as if they were directories. Defaults
+	 * 	to `false`. No protection against circular symbolic links is provided.
 	 * @returns {AsyncIterable<HfsWalkEntry>} A promise that resolves with the
 	 * 	directory entries.
 	 * @throws {TypeError} If the directory path is not a string or URL.
@@ -528,15 +531,29 @@ export class Hfs {
 	 */
 	async *walk(
 		dirPath,
-		{ directoryFilter = () => true, entryFilter = () => true } = {},
+		{
+			directoryFilter = () => true,
+			entryFilter = () => true,
+			followSymlinks = false,
+		} = {},
 	) {
 		assertValidFileOrDirPath(dirPath);
-		this.#log("walk", dirPath, { directoryFilter, entryFilter });
+		this.#log("walk", dirPath, {
+			directoryFilter,
+			entryFilter,
+			followSymlinks,
+		});
 
 		// inner function for recursion without additional logging
 		const walk = async function* (
 			dirPath,
-			{ directoryFilter, entryFilter, parentPath = "", depth = 1 },
+			{
+				directoryFilter,
+				entryFilter,
+				followSymlinks,
+				parentPath = "",
+				depth = 1,
+			},
 		) {
 			let dirEntries;
 
@@ -609,10 +626,38 @@ export class Hfs {
 						yield walkEntry;
 					}
 
-					// if it's a directory then yield the entry and walk the directory
-					if (listEntry.isDirectory) {
+					// make sure there's a trailing slash on the directory path before appending
+					const entryPath =
+						dirPath instanceof URL
+							? new URL(
+									listEntry.name,
+									dirPath.href.endsWith("/")
+										? dirPath.href
+										: `${dirPath.href}/`,
+								)
+							: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
+
+					// directories are always walked; symlinks to directories are
+					// only walked when followSymlinks is true (a symlink reports
+					// isDirectory as false, so the target must be checked)
+					let shouldWalkDirectory = listEntry.isDirectory;
+
+					if (
+						!shouldWalkDirectory &&
+						followSymlinks &&
+						listEntry.isSymlink
+					) {
+						shouldWalkDirectory =
+							await this.#callImplMethodWithoutLog(
+								"isDirectory",
+								entryPath,
+							);
+					}
+
+					// if it's a directory then walk the directory
+					if (shouldWalkDirectory) {
 						// if the directory filter returns false, skip the directory
-						let shouldWalkDirectory = directoryFilter(walkEntry);
+						shouldWalkDirectory = directoryFilter(walkEntry);
 						if (shouldWalkDirectory.then) {
 							shouldWalkDirectory = await shouldWalkDirectory;
 						}
@@ -621,20 +666,10 @@ export class Hfs {
 							continue;
 						}
 
-						// make sure there's a trailing slash on the directory path before appending
-						const directoryPath =
-							dirPath instanceof URL
-								? new URL(
-										listEntry.name,
-										dirPath.href.endsWith("/")
-											? dirPath.href
-											: `${dirPath.href}/`,
-									)
-								: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
-
-						yield* walk(directoryPath, {
+						yield* walk(entryPath, {
 							directoryFilter,
 							entryFilter,
+							followSymlinks,
 							parentPath: walkEntry.path,
 							depth: depth + 1,
 						});
@@ -648,7 +683,7 @@ export class Hfs {
 			}
 		}.bind(this);
 
-		yield* walk(dirPath, { directoryFilter, entryFilter });
+		yield* walk(dirPath, { directoryFilter, entryFilter, followSymlinks });
 	}
 
 	/**

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -1625,7 +1625,11 @@ describe("Hfs", () => {
 						methodName: "walk",
 						args: [
 							"/path/to/dir",
-							{ directoryFilter, entryFilter },
+							{
+								directoryFilter,
+								entryFilter,
+								followSymlinks: false,
+							},
 						],
 					},
 				},
@@ -1717,6 +1721,236 @@ describe("Hfs", () => {
 			}
 
 			assert.deepStrictEqual(entries, traversed);
+		});
+
+		describe("followSymlinks", () => {
+			const symlinkData = {
+				"/root": [
+					{
+						name: "dir-link",
+						isFile: false,
+						isDirectory: false,
+						isSymlink: true,
+					},
+					{
+						name: "file-link",
+						isFile: false,
+						isDirectory: false,
+						isSymlink: true,
+					},
+					{
+						name: "broken-link",
+						isFile: false,
+						isDirectory: false,
+						isSymlink: true,
+					},
+					{
+						name: "file.txt",
+						isFile: true,
+						isDirectory: false,
+						isSymlink: false,
+					},
+				],
+				"/root/dir-link": [
+					{
+						name: "inside.txt",
+						isFile: true,
+						isDirectory: false,
+						isSymlink: false,
+					},
+				],
+			};
+
+			// the paths that resolve to directories through a symlink
+			const symlinkedDirectories = new Set(["/root/dir-link"]);
+
+			function normalizePath(dirPath) {
+				if (dirPath instanceof URL) {
+					dirPath = dirPath.pathname;
+				}
+
+				if (dirPath.endsWith("/")) {
+					dirPath = dirPath.slice(0, -1);
+				}
+
+				return dirPath;
+			}
+
+			let symlinkHfs;
+			let isDirectoryCalls;
+
+			beforeEach(() => {
+				isDirectoryCalls = [];
+				symlinkHfs = new Hfs({
+					impl: {
+						list(dirPath) {
+							return symlinkData[normalizePath(dirPath)] ?? [];
+						},
+
+						// mimics a stat() that follows the symlink
+						isDirectory(dirPath) {
+							isDirectoryCalls.push(dirPath);
+							return symlinkedDirectories.has(
+								normalizePath(dirPath),
+							);
+						},
+					},
+				});
+			});
+
+			it("should not walk symlinked directories by default", async () => {
+				const paths = [];
+
+				for await (const entry of symlinkHfs.walk("/root")) {
+					paths.push(entry.path);
+				}
+
+				assert.deepStrictEqual(paths, [
+					"dir-link",
+					"file-link",
+					"broken-link",
+					"file.txt",
+				]);
+				assert.deepStrictEqual(isDirectoryCalls, []);
+			});
+
+			it("should not walk symlinked directories when followSymlinks is false", async () => {
+				const paths = [];
+
+				for await (const entry of symlinkHfs.walk("/root", {
+					followSymlinks: false,
+				})) {
+					paths.push(entry.path);
+				}
+
+				assert.deepStrictEqual(paths, [
+					"dir-link",
+					"file-link",
+					"broken-link",
+					"file.txt",
+				]);
+				assert.deepStrictEqual(isDirectoryCalls, []);
+			});
+
+			it("should walk symlinked directories when followSymlinks is true", async () => {
+				const entries = [];
+
+				for await (const entry of symlinkHfs.walk("/root", {
+					followSymlinks: true,
+				})) {
+					entries.push(entry);
+				}
+
+				assert.deepStrictEqual(
+					entries.map(entry => entry.path),
+					[
+						"dir-link",
+						"dir-link/inside.txt",
+						"file-link",
+						"broken-link",
+						"file.txt",
+					],
+				);
+
+				// the symlink entry itself is still reported as a symlink
+				assert.deepStrictEqual(entries[0], {
+					name: "dir-link",
+					path: "dir-link",
+					depth: 1,
+					isFile: false,
+					isDirectory: false,
+					isSymlink: true,
+				});
+
+				assert.deepStrictEqual(entries[1], {
+					name: "inside.txt",
+					path: "dir-link/inside.txt",
+					depth: 2,
+					isFile: true,
+					isDirectory: false,
+					isSymlink: false,
+				});
+			});
+
+			it("should only check symlink entries when followSymlinks is true", async () => {
+				// eslint-disable-next-line no-unused-vars -- Needed for async iteration
+				for await (const entry of symlinkHfs.walk("/root", {
+					followSymlinks: true,
+				}));
+
+				assert.deepStrictEqual(isDirectoryCalls, [
+					"/root/dir-link",
+					"/root/file-link",
+					"/root/broken-link",
+				]);
+			});
+
+			it("should walk symlinked directories when passed a URL", async () => {
+				const paths = [];
+
+				for await (const entry of symlinkHfs.walk(
+					new URL("file:///root"),
+					{ followSymlinks: true },
+				)) {
+					paths.push(entry.path);
+				}
+
+				assert.deepStrictEqual(paths, [
+					"dir-link",
+					"dir-link/inside.txt",
+					"file-link",
+					"broken-link",
+					"file.txt",
+				]);
+				assert.ok(
+					isDirectoryCalls.every(dirPath => dirPath instanceof URL),
+					"isDirectory() should receive URLs.",
+				);
+				assert.strictEqual(
+					isDirectoryCalls[0].href,
+					"file:///root/dir-link",
+				);
+			});
+
+			it("should pass symlinked directories through directoryFilter", async () => {
+				const paths = [];
+				const filtered = [];
+
+				for await (const entry of symlinkHfs.walk("/root", {
+					followSymlinks: true,
+					directoryFilter(entry) {
+						filtered.push(entry.path);
+						return false;
+					},
+				})) {
+					paths.push(entry.path);
+				}
+
+				assert.deepStrictEqual(filtered, ["dir-link"]);
+				assert.deepStrictEqual(paths, [
+					"dir-link",
+					"file-link",
+					"broken-link",
+					"file.txt",
+				]);
+			});
+
+			it("should reject a promise when followSymlinks is true and the impl has no isDirectory() method", () => {
+				const noIsDirectoryHfs = new Hfs({
+					impl: {
+						list(dirPath) {
+							return symlinkData[normalizePath(dirPath)] ?? [];
+						},
+					},
+				});
+
+				return assert.rejects(async () => {
+					// eslint-disable-next-line no-unused-vars -- Needed for async iteration
+					for await (const entry of noIsDirectoryHfs.walk("/root", {
+						followSymlinks: true,
+					}));
+				}, /isDirectory/u);
+			});
 		});
 
 		it("should return the list of files and directories when passed a URL without a trailing slash", async () => {

--- a/packages/deno/tests/deno-hfs.test.js
+++ b/packages/deno/tests/deno-hfs.test.js
@@ -314,5 +314,133 @@ describe("DenoHfsImpl Customizations", () => {
 				await Deno.remove(tmpDir, { recursive: true });
 			}
 		});
+
+		/**
+		 * Creates a temp directory with this layout:
+		 *
+		 * 	target/inside.txt
+		 * 	dir-link -> target
+		 * 	file-link -> target/inside.txt
+		 * 	broken-link -> missing
+		 *
+		 * @returns {Promise<string|undefined>} The temp directory path, or
+		 * 	undefined if symlinks can't be created on this system.
+		 */
+		async function createSymlinkFixture() {
+			const tmpDir = await Deno.makeTempDir({
+				prefix: "humanfs-walk-symlink-",
+			});
+			const target = path.join(tmpDir, "target");
+
+			await Deno.mkdir(target);
+			await Deno.writeTextFile(path.join(target, "inside.txt"), "hello");
+
+			try {
+				await Deno.symlink(target, path.join(tmpDir, "dir-link"), {
+					type: "dir",
+				});
+				await Deno.symlink(
+					path.join(target, "inside.txt"),
+					path.join(tmpDir, "file-link"),
+					{ type: "file" },
+				);
+				await Deno.symlink(
+					path.join(tmpDir, "missing"),
+					path.join(tmpDir, "broken-link"),
+					{ type: "file" },
+				);
+			} catch (err) {
+				if (
+					err instanceof Deno.errors.PermissionDenied ||
+					err.code === "EPERM"
+				) {
+					await Deno.remove(tmpDir, { recursive: true });
+					return undefined; // symlinks require elevated privileges on this OS; skip
+				}
+				throw err;
+			}
+
+			return tmpDir;
+		}
+
+		async function collectPaths(dirPath, options) {
+			const hfs = new DenoHfs();
+			const paths = [];
+
+			for await (const entry of hfs.walk(dirPath, options)) {
+				paths.push(entry.path);
+			}
+
+			return paths.sort();
+		}
+
+		it("should not walk into symlinked directories by default", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(tmpDir);
+
+				assertEquals(paths, [
+					"broken-link",
+					"dir-link",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
+			} finally {
+				await Deno.remove(tmpDir, { recursive: true });
+			}
+		});
+
+		it("should walk into symlinked directories when followSymlinks is true", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(tmpDir, {
+					followSymlinks: true,
+				});
+
+				assertEquals(paths, [
+					"broken-link",
+					"dir-link",
+					"dir-link/inside.txt",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
+			} finally {
+				await Deno.remove(tmpDir, { recursive: true });
+			}
+		});
+
+		it("should walk into symlinked directories when followSymlinks is true and passed a URL", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(path.toFileUrl(tmpDir), {
+					followSymlinks: true,
+				});
+
+				assertEquals(paths, [
+					"broken-link",
+					"dir-link",
+					"dir-link/inside.txt",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
+			} finally {
+				await Deno.remove(tmpDir, { recursive: true });
+			}
+		});
 	});
 });

--- a/packages/node/tests/node-hfs.test.js
+++ b/packages/node/tests/node-hfs.test.js
@@ -10,7 +10,7 @@
 import { NodeHfsImpl, NodeHfs } from "../src/node-hfs.js";
 import assert from "node:assert";
 import fsp from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import os from "node:os";
 import path from "node:path";
 import { HfsImplTester } from "@humanfs/test";
@@ -368,6 +368,127 @@ describe("NodeHfsImpl Customizations", () => {
 				}
 
 				assert.deepStrictEqual(paths.sort(), ["file.txt", "subdir"]);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		/**
+		 * Creates a temp directory with this layout:
+		 *
+		 * 	target/inside.txt
+		 * 	dir-link -> target
+		 * 	file-link -> target/inside.txt
+		 * 	broken-link -> missing
+		 *
+		 * @returns {Promise<string|undefined>} The temp directory path, or
+		 * 	undefined if symlinks can't be created on this system.
+		 */
+		async function createSymlinkFixture() {
+			const tmpDir = await fsp.mkdtemp(
+				path.join(os.tmpdir(), "humanfs-walk-symlink-"),
+			);
+			const target = path.join(tmpDir, "target");
+
+			await fsp.mkdir(target);
+			await fsp.writeFile(path.join(target, "inside.txt"), "hello");
+
+			try {
+				await fsp.symlink(target, path.join(tmpDir, "dir-link"));
+				await fsp.symlink(
+					path.join(target, "inside.txt"),
+					path.join(tmpDir, "file-link"),
+				);
+				await fsp.symlink(
+					path.join(tmpDir, "missing"),
+					path.join(tmpDir, "broken-link"),
+				);
+			} catch (err) {
+				if (err.code === "EPERM") {
+					await fsp.rm(tmpDir, { recursive: true, force: true });
+					return undefined; // symlinks require elevated privileges on this OS; skip
+				}
+				throw err;
+			}
+
+			return tmpDir;
+		}
+
+		async function collectPaths(dirPath, options) {
+			const hfs = new NodeHfs({ fsp });
+			const paths = [];
+
+			for await (const entry of hfs.walk(dirPath, options)) {
+				paths.push(entry.path);
+			}
+
+			return paths.sort();
+		}
+
+		it("should not walk into symlinked directories by default", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(tmpDir);
+
+				assert.deepStrictEqual(paths, [
+					"broken-link",
+					"dir-link",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		it("should walk into symlinked directories when followSymlinks is true", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(tmpDir, {
+					followSymlinks: true,
+				});
+
+				assert.deepStrictEqual(paths, [
+					"broken-link",
+					"dir-link",
+					"dir-link/inside.txt",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		it("should walk into symlinked directories when followSymlinks is true and passed a URL", async () => {
+			const tmpDir = await createSymlinkFixture();
+			if (!tmpDir) {
+				return;
+			}
+
+			try {
+				const paths = await collectPaths(pathToFileURL(tmpDir), {
+					followSymlinks: true,
+				});
+
+				assert.deepStrictEqual(paths, [
+					"broken-link",
+					"dir-link",
+					"dir-link/inside.txt",
+					"file-link",
+					"target",
+					"target/inside.txt",
+				]);
 			} finally {
 				await fsp.rm(tmpDir, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Summary

Adds an opt-in `followSymlinks` option to `hfs.walk()`. It defaults to `false`, so there is no behavior change for existing callers.

`walk()` only recursed when an entry's `isDirectory` was `true`, but a symlink pointing at a directory reports `isDirectory: false` / `isSymlink: true`, so symlinked directories were never traversed. This broke file discovery in ESLint after it moved to humanfs (eslint/eslint#19963).

When `followSymlinks: true`:

- Each symlink entry is resolved through the impl's `isDirectory()` (which `stat`s through the link in both Node and Deno). Entries that point to a directory are passed to `directoryFilter` and, if not filtered out, walked.
- Symlinks to files and broken links are emitted as entries but never descended into (`isDirectory()` returns `false` on `ENOENT`).
- The symlink entry itself is still reported with `isSymlink: true` / `isDirectory: false`.
- `isDirectory()` is only called for symlink entries and only when the option is on, so the default path does no extra I/O.
- No cycle protection is provided (the `HfsImpl` interface has no `realpath`); this is called out in the docs.

## Changes

- `packages/core/src/hfs.js` — `followSymlinks` option on `walk()`; included in the method's log entry.
- `packages/core/tests/hfs.test.js` — 7 mock-impl tests: default off, explicit off, on, URL input, `directoryFilter` interaction, which paths are checked, and a clear error when the impl lacks `isDirectory()`.
- `packages/node/tests/node-hfs.test.js` — 3 real-filesystem tests against a temp tree with a directory link, file link, and broken link (skips on `EPERM`).
- `packages/deno/tests/deno-hfs.test.js` — the same 3 tests for `DenoHfs`.
- `docs/directory-operations.md` — documents the option and its semantics, and fixes the stale `@humanfs/types.ts` links (file is `hfs-types.ts`).

## Credit

This supersedes #163 by @bitpshr, which proposed the same approach (resolving symlink entries via `isDirectory()`). This PR builds on that design and adds URL handling, file-link/broken-link coverage, Deno tests, the missing-`isDirectory()` error path, and documentation. Paul is credited as a co-author on the commit.

Fixes #162
Closes #163

## Test plan

Rebased onto `main` (on top of #168's Node 24 / Vitest migration and #166's `walk()` ENOENT fix). The symlink logic is layered into #166's iterator loop; the earlier lockfile/`allowScripts` commit and the `--allow-env=DEBUG` change to the Deno test script were dropped because `main` already carries them.

- [x] `packages/core`: 198 passing
- [x] `packages/node`: 202 passing
- [x] `packages/deno`: 2 passed (128 steps), 0 failed
- [x] `packages/memory`: 158 passing, `packages/web`: 184 passing, `packages/box`: 132 passing
- [x] `eslint .` clean; `prettier --check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFgSKfUvF5SSCcbLL5cFyT
