### PR TITLE
fix: Ensure walk() skips directories deleted before they are listed

### DIFF
--- a/packages/core/src/hfs.js
+++ b/packages/core/src/hfs.js
@@ -555,56 +555,95 @@ export class Hfs {
 				throw error;
 			}
 
-			for await (const listEntry of dirEntries) {
-				const walkEntry = {
-					path: listEntry.name,
-					depth,
-					...listEntry,
-				};
+			/*
+			 * list() is usually an async generator, which means the directory
+			 * isn't actually read until the iterator is first advanced. That
+			 * means an ENOENT error (e.g., the directory was deleted after the
+			 * parent was listed) is thrown by next() rather than by the call
+			 * to list() itself, so it must be caught here as well.
+			 */
+			const iterator =
+				dirEntries[Symbol.asyncIterator]?.() ??
+				dirEntries[Symbol.iterator]();
+			let done = false;
 
-				if (parentPath) {
-					walkEntry.path = `${parentPath}/${walkEntry.path}`;
-				}
+			try {
+				while (!done) {
+					let result;
 
-				// first emit the entry but only if the entry filter returns true
-				let shouldEmitEntry = entryFilter(walkEntry);
-				if (shouldEmitEntry.then) {
-					shouldEmitEntry = await shouldEmitEntry;
-				}
+					try {
+						result = await iterator.next();
+					} catch (error) {
+						// if the directory does not exist then stop walking it
+						if (error.code === "ENOENT") {
+							return;
+						}
 
-				if (shouldEmitEntry) {
-					yield walkEntry;
-				}
-
-				// if it's a directory then yield the entry and walk the directory
-				if (listEntry.isDirectory) {
-					// if the directory filter returns false, skip the directory
-					let shouldWalkDirectory = directoryFilter(walkEntry);
-					if (shouldWalkDirectory.then) {
-						shouldWalkDirectory = await shouldWalkDirectory;
+						// otherwise, rethrow the error
+						throw error;
 					}
 
-					if (!shouldWalkDirectory) {
-						continue;
+					if (result.done) {
+						done = true;
+						break;
 					}
 
-					// make sure there's a trailing slash on the directory path before appending
-					const directoryPath =
-						dirPath instanceof URL
-							? new URL(
-									listEntry.name,
-									dirPath.href.endsWith("/")
-										? dirPath.href
-										: `${dirPath.href}/`,
-								)
-							: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
+					const listEntry = result.value;
+					const walkEntry = {
+						path: listEntry.name,
+						depth,
+						...listEntry,
+					};
 
-					yield* walk(directoryPath, {
-						directoryFilter,
-						entryFilter,
-						parentPath: walkEntry.path,
-						depth: depth + 1,
-					});
+					if (parentPath) {
+						walkEntry.path = `${parentPath}/${walkEntry.path}`;
+					}
+
+					// first emit the entry but only if the entry filter returns true
+					let shouldEmitEntry = entryFilter(walkEntry);
+					if (shouldEmitEntry.then) {
+						shouldEmitEntry = await shouldEmitEntry;
+					}
+
+					if (shouldEmitEntry) {
+						yield walkEntry;
+					}
+
+					// if it's a directory then yield the entry and walk the directory
+					if (listEntry.isDirectory) {
+						// if the directory filter returns false, skip the directory
+						let shouldWalkDirectory = directoryFilter(walkEntry);
+						if (shouldWalkDirectory.then) {
+							shouldWalkDirectory = await shouldWalkDirectory;
+						}
+
+						if (!shouldWalkDirectory) {
+							continue;
+						}
+
+						// make sure there's a trailing slash on the directory path before appending
+						const directoryPath =
+							dirPath instanceof URL
+								? new URL(
+										listEntry.name,
+										dirPath.href.endsWith("/")
+											? dirPath.href
+											: `${dirPath.href}/`,
+									)
+								: `${dirPath.endsWith("/") ? dirPath : `${dirPath}/`}${listEntry.name}`;
+
+						yield* walk(directoryPath, {
+							directoryFilter,
+							entryFilter,
+							parentPath: walkEntry.path,
+							depth: depth + 1,
+						});
+					}
+				}
+			} finally {
+				// close the iterator if the loop exited early (error or break)
+				if (!done) {
+					await iterator.return?.();
 				}
 			}
 		}.bind(this);

--- a/packages/core/tests/hfs.test.js
+++ b/packages/core/tests/hfs.test.js
@@ -1877,7 +1877,177 @@ describe("Hfs", () => {
 			assert.deepStrictEqual(deepEntries, expected);
 		});
 
-		it("should silently skip directories when list() throws ENONENT", async () => {
+		describe("when list() is an async generator", () => {
+			function normalizePath(dirPath) {
+				if (dirPath instanceof URL) {
+					dirPath = dirPath.pathname;
+				}
+
+				if (dirPath.endsWith("/")) {
+					dirPath = dirPath.slice(0, -1);
+				}
+
+				return dirPath;
+			}
+
+			it("should silently skip directories when list() throws ENOENT on iteration", async () => {
+				const hfs = new Hfs({
+					impl: {
+						// like NodeHfsImpl#list(), the read happens on first next()
+						async *list(dirPath) {
+							dirPath = normalizePath(dirPath);
+
+							if (dirPath === "/path/to/dir/subdir1") {
+								throw new NotFoundError(dirPath);
+							}
+
+							yield* data[dirPath] ?? [];
+						},
+					},
+				});
+
+				const entries = [];
+				for await (const entry of hfs.walk("/path/to/dir")) {
+					entries.push(entry);
+				}
+
+				const expected = traversed.filter(
+					entry => !entry.path.includes("subdir1/"),
+				);
+				assert.deepStrictEqual(entries, expected);
+			});
+
+			it("should return no entries when list() throws ENOENT for the walked directory", async () => {
+				const hfs = new Hfs({
+					impl: {
+						// eslint-disable-next-line require-yield -- intentionally throws
+						async *list(dirPath) {
+							throw new NotFoundError(dirPath);
+						},
+					},
+				});
+
+				const entries = [];
+				for await (const entry of hfs.walk("/path/to/missing")) {
+					entries.push(entry);
+				}
+
+				assert.deepStrictEqual(entries, []);
+			});
+
+			it("should silently skip directories when list() throws ENOENT partway through iteration", async () => {
+				const hfs = new Hfs({
+					impl: {
+						async *list(dirPath) {
+							dirPath = normalizePath(dirPath);
+							const entries = data[dirPath] ?? [];
+
+							if (dirPath === "/path/to/dir/subdir1") {
+								yield entries[0];
+								throw new NotFoundError(dirPath);
+							}
+
+							yield* entries;
+						},
+					},
+				});
+
+				const entries = [];
+				for await (const entry of hfs.walk("/path/to/dir")) {
+					entries.push(entry);
+				}
+
+				// only the first entry of subdir1 (and its subtree) is emitted
+				const expected = traversed.filter(
+					entry =>
+						!entry.path.includes("subdir1/") ||
+						entry.path.startsWith("subdir1/subdir3"),
+				);
+				assert.deepStrictEqual(entries, expected);
+			});
+
+			it("should rethrow errors other than ENOENT thrown on iteration", () => {
+				const error = new Error("Boom!");
+				const hfs = new Hfs({
+					impl: {
+						async *list(dirPath) {
+							dirPath = normalizePath(dirPath);
+
+							if (dirPath === "/path/to/dir/subdir1") {
+								throw error;
+							}
+
+							yield* data[dirPath] ?? [];
+						},
+					},
+				});
+
+				return assert.rejects(async () => {
+					// eslint-disable-next-line no-unused-vars -- Needed for async iteration
+					for await (const entry of hfs.walk("/path/to/dir"));
+				}, error);
+			});
+
+			it("should close the list() iterators when the walk is exited early", async () => {
+				const closed = [];
+				const hfs = new Hfs({
+					impl: {
+						async *list(dirPath) {
+							dirPath = normalizePath(dirPath);
+
+							try {
+								yield* data[dirPath] ?? [];
+							} finally {
+								closed.push(dirPath);
+							}
+						},
+					},
+				});
+
+				for await (const entry of hfs.walk("/path/to/dir")) {
+					if (entry.path === "subdir1/subdir3") {
+						break;
+					}
+				}
+
+				// both the root and subdir1 iterators were mid-iteration
+				assert.deepStrictEqual(closed, [
+					"/path/to/dir/subdir1",
+					"/path/to/dir",
+				]);
+			});
+
+			it("should close the list() iterator when entryFilter throws", async () => {
+				const closed = [];
+				const error = new Error("Error in entryFilter");
+				const hfs = new Hfs({
+					impl: {
+						async *list(dirPath) {
+							dirPath = normalizePath(dirPath);
+
+							try {
+								yield* data[dirPath] ?? [];
+							} finally {
+								closed.push(dirPath);
+							}
+						},
+					},
+				});
+
+				await assert.rejects(async () => {
+					// eslint-disable-next-line no-unused-vars -- Needed for async iteration
+					for await (const entry of hfs.walk("/path/to/dir", {
+						entryFilter() {
+							throw error;
+						},
+					}));
+				}, error);
+
+				assert.deepStrictEqual(closed, ["/path/to/dir"]);
+			});
+		});
+
+		it("should silently skip directories when list() throws ENOENT", async () => {
 			const hfs = new Hfs({
 				impl: {
 					list(dirPath) {

--- a/packages/deno/tests/deno-hfs.test.js
+++ b/packages/deno/tests/deno-hfs.test.js
@@ -13,7 +13,7 @@ import {
 	beforeEach,
 	afterEach,
 } from "https://deno.land/std/testing/bdd.ts";
-import { DenoHfsImpl } from "../src/deno-hfs.js";
+import { DenoHfsImpl, DenoHfs } from "../src/deno-hfs.js";
 import { HfsImplTester } from "../../test/src/index.js";
 import {
 	assert,
@@ -272,6 +272,47 @@ describe("DenoHfsImpl Customizations", () => {
 				() => impl.write(".hfs/foo", HELLO_WORLD_BYTES),
 				/Boom!/,
 			);
+		});
+	});
+
+	describe("walk()", () => {
+		it("should not throw when a directory is deleted before it is listed", async () => {
+			const tmpDir = await Deno.makeTempDir({
+				prefix: "humanfs-walk-enoent-",
+			});
+
+			try {
+				const subdir = path.join(tmpDir, "subdir");
+				await Deno.mkdir(subdir);
+				await Deno.writeTextFile(
+					path.join(subdir, "inside.txt"),
+					"hello",
+				);
+				await Deno.writeTextFile(
+					path.join(tmpDir, "file.txt"),
+					"hello",
+				);
+
+				const hfs = new DenoHfs();
+				const paths = [];
+
+				for await (const entry of hfs.walk(tmpDir, {
+					// simulate another process deleting the directory after
+					// it was found but before walk() lists its contents
+					async directoryFilter(entry) {
+						if (entry.name === "subdir") {
+							await Deno.remove(subdir, { recursive: true });
+						}
+						return true;
+					},
+				})) {
+					paths.push(entry.path);
+				}
+
+				assertEquals(paths.sort(), ["file.txt", "subdir"]);
+			} finally {
+				await Deno.remove(tmpDir, { recursive: true });
+			}
 		});
 	});
 });

--- a/packages/node/tests/node-hfs.test.js
+++ b/packages/node/tests/node-hfs.test.js
@@ -7,7 +7,7 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import { NodeHfsImpl } from "../src/node-hfs.js";
+import { NodeHfsImpl, NodeHfs } from "../src/node-hfs.js";
 import assert from "node:assert";
 import fsp from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -335,6 +335,41 @@ describe("NodeHfsImpl Customizations", () => {
 				assert.strictEqual(linkTarget, secret);
 			} finally {
 				await fsp.rm(tmpDir, { recursive: true });
+			}
+		});
+	});
+
+	describe("walk()", () => {
+		it("should not throw when a directory is deleted before it is listed", async () => {
+			const tmpDir = await fsp.mkdtemp(
+				path.join(os.tmpdir(), "humanfs-walk-enoent-"),
+			);
+
+			try {
+				const subdir = path.join(tmpDir, "subdir");
+				await fsp.mkdir(subdir);
+				await fsp.writeFile(path.join(subdir, "inside.txt"), "hello");
+				await fsp.writeFile(path.join(tmpDir, "file.txt"), "hello");
+
+				const hfs = new NodeHfs({ fsp });
+				const paths = [];
+
+				for await (const entry of hfs.walk(tmpDir, {
+					// simulate another process deleting the directory after
+					// it was found but before walk() lists its contents
+					async directoryFilter(entry) {
+						if (entry.name === "subdir") {
+							await fsp.rm(subdir, { recursive: true });
+						}
+						return true;
+					},
+				})) {
+					paths.push(entry.path);
+				}
+
+				assert.deepStrictEqual(paths.sort(), ["file.txt", "subdir"]);
+			} finally {
+				await fsp.rm(tmpDir, { recursive: true, force: true });
 			}
 		});
 	});


### PR DESCRIPTION
## Summary

`walk()` crashed with `ENOENT` when a directory was deleted between being discovered and being listed — the race hit by ESLint users running other tools concurrently (#154, eslint/eslint#18955).

## Root cause

`NodeHfsImpl#list()` and `DenoHfsImpl#list()` are async generators, so `await impl.list(dir)` only returns an iterator; `readdir` doesn't run until the first `next()`. The `try/catch` from #135 wrapped only the `list()` call, so the `ENOENT` surfaced inside `for await`, outside the catch. The #135 test didn't catch this because its mock `list()` was a plain function that threw synchronously.

## Fix

`walk()` now drives the `list()` iterator manually (`Symbol.asyncIterator`, falling back to `Symbol.iterator` so array-returning impls still work) and wraps each `next()`:

- `ENOENT` → stop walking that directory silently (entries already yielded from it are kept)
- any other error → rethrown
- on early exit (consumer `break`, filter throwing) the iterator's `return()` is called, matching `for await` cleanup semantics

The existing catch around the `list()` call is kept for impls that throw synchronously.

## Tests

- **core** (6 new, mock async-generator `list()`): skip on `ENOENT` at first `next()`; walked root missing → no entries; `ENOENT` partway through iteration; non-`ENOENT` errors rethrow; iterators closed on early `break` and on `entryFilter` throw. Also fixed the "ENONENT" typo in the existing test name.
- **node** and **deno** (1 each, real filesystem): `directoryFilter` deletes the subdirectory after `walk()` discovers it but before it's listed — the exact race from the issue.

Verified the new tests reproduce the bug: against the unfixed `hfs.js`, the 3 core `ENOENT` tests and the Node real-FS test fail; with the fix, core 191 / node 199 / deno 125 steps pass.

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DHXVwqQ4iawKrV2DxPVKV
